### PR TITLE
Added 'data-dismiss="modal"' to the close link in modals

### DIFF
--- a/views/body.ejs
+++ b/views/body.ejs
@@ -88,7 +88,7 @@
 <iframe id="downloader" class="hide"></iframe>
 <div id="modal-generic" class="modal hide fade in">
   <div class="modal-header">
-    <a href="#" class="close">&times;</a>
+    <a href="#" class="close" data-dismiss="modal">&times;</a>
     <h3></h3>
   </div>
   <div class="modal-body">


### PR DESCRIPTION
Very small and trivial, I know, but the modals don't close when clicking on the "x". Needs the extra 'data-dismiss="modal"' for that.
