### PR TITLE
Support bold text in Chrome

### DIFF
--- a/views/style.ejs
+++ b/views/style.ejs
@@ -1,7 +1,7 @@
 <% if(env === 'production') { %>
-  <link href="https://fonts.googleapis.com/css?family=Arvo&subset=latin" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Arvo:400,700&subset=latin" rel="stylesheet" type="text/css">
   <link href="/css/style-<%- app_version %>.min.css" rel="stylesheet">
 <% } else { %>
-  <link href="https://fonts.googleapis.com/css?family=Arvo&subset=latin" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Arvo:400,700&subset=latin" rel="stylesheet" type="text/css">
   <link href="/css/style.css" rel="stylesheet">
 <% }%>


### PR DESCRIPTION
In Chrome 25.0.1323.1, text that should be bold:

`**bold!**`

is not with the Arvo web font. Instead the tracking increases slightly (letters spread out a bit more), which is not very obvious.

The attached change pulls down the Bold variant as well to resolve the issue.

Note however, that bold works fine in Firefox (maybe others too...) without this.
