### PR TITLE
Fix the 'ctrl-s' problem

### DIFF
--- a/public/js/dillinger.js
+++ b/public/js/dillinger.js
@@ -785,7 +785,7 @@ $(function(){
          saveFile() 
        }
     }
-    
+    editor.commands.addCommand(command);
   }
 
   /**


### PR DESCRIPTION
Fix a bug that when pressing 'ctrl-s' in editor will invoke the browser's "Save as" function.
