### PR TITLE
Switch to phantomjs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-markdown": ">=0.1.0",
     "lodash": ">=0.6.1",
     "dbox": "0.6.3",
-    "node-phantom": "~0.2.3"
+    "phantomjs": "~1.9.0-6"
   },
   "devDependencies": {
     "smoosh": ">=0.3.2",

--- a/plugins/core/render.js
+++ b/plugins/core/render.js
@@ -1,0 +1,24 @@
+var page = require('webpage').create();
+var system = require('system');
+var address, output;
+
+if (system.args.length == 3) {
+  address = system.args[1];
+  output = system.args[2];
+  page.viewportSize = { width: 1024, height: 768 };
+  page.paperSize = { format: 'A4', orientation: 'portrait', margin: '1cm' };
+
+  page.open(address, function (status) {
+    if (status !== 'success') {
+      console.log('Unable to load the address!');
+      phantom.exit();
+    } else {
+      window.setTimeout(function () {
+        page.render(output);
+        phantom.exit();
+      }, 200);
+    }
+  });
+} else {
+  phantom.exit(1);
+}


### PR DESCRIPTION
Keep going on #80, 
because I think phantomJS is the easiest way to convert html to pdf,
I try to solve the problem can't install phantomJS on Nodejitsu.

Use https://github.com/Obvious/phantomjs module instead, it will build a executive phantomJS not just bridge nodejs and phantomJS. Hope this way can solve the problem.
