### PR TITLE
Fix "Loading" container is not removed in IE9

### DIFF
--- a/public/js/dillinger.js
+++ b/public/js/dillinger.js
@@ -1721,16 +1721,16 @@ function syncPreview() {
 window.onload = function(){
   var $loading = $('#loading')
   
-  if ($.support.transition!=false){
-  $loading
-    .bind( $.support.transitionEnd, function(){
-      $('#main').removeClass('bye')
-      $loading.remove()
-    })
-    .addClass('fade_slow');
-  } else  {
-      $('#main').removeClass('bye')
-      $loading.remove()   
+  if ($.support.transition){
+    $loading
+      .bind( $.support.transitionEnd, function(){
+        $('#main').removeClass('bye')
+        $loading.remove()
+      })
+      .addClass('fade_slow');
+  } else {
+    $('#main').removeClass('bye')
+    $loading.remove()   
   }
   
   /**
@@ -1740,4 +1740,3 @@ window.onload = function(){
   window.ace.edit('editor').session.on('changeScrollTop', syncPreview);
   window.ace.edit('editor').session.selection.on('changeCursor', syncPreview);
 }
-


### PR DESCRIPTION
Don't laugh but I discovered that  this wonderful application does not work correctly with IE 9.
"Loading" div is not removed.
After looking at it I realized that  `$.support.transitionEnd` is not fired because IE9 does not support transitions (what a suprise).
Doing this modyfication made it work on IE9 on my computer
