### PR TITLE
Add enhanced configuration and make Google Webmaster Meta Tag optional

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+var config = require('./config')();
 var express = require('express')
   , routes = require('./routes')
   , http = require('http')
@@ -29,7 +30,8 @@ app.configure(function(){
   // Setup local variables to be available in the views.
   app.locals.title = "Online Markdown Editor - Dillinger, the Last Markdown Editor ever."
   app.locals.description = "Dillinger is an Online cloud based HTML5 filled Markdown Editor. Sync with Dropbox and Github. 100% Open Source!"
-  app.locals.googleVerify = "DAyGOgtsg8rJpq9VVktKzDkQ1UhXm1FYl8SD47hPkjA"
+  if (config.googleWebmasterMeta)
+    app.locals.googleWebmasterMeta = config.googleWebmasterMeta;
   app.locals.node_version = process.version.replace('v', '')
   app.locals.app_version = require('./package.json').version
   app.locals.env = process.env.NODE_ENV

--- a/config.js
+++ b/config.js
@@ -1,0 +1,7 @@
+var rc = require('rc');
+var defaultConfig = {
+  // googleWebmasterMeta: 'your google site verification content string - used for enabling Google Webmaster tools on the site',
+};
+module.exports = function() {
+  return rc('dillinger', defaultConfig);
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "express": ">=3.0.0rc3",
+    "rc": "0.3.0",
     "stylus": ">=0.28.2",
     "ejs": ">=0.8.1",
     "request": ">=2.9.203",

--- a/views/head.ejs
+++ b/views/head.ejs
@@ -3,7 +3,9 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="google-site-verification" content="<%= googleVerify %>" />
+<% if(locals.googleWebmasterMeta) { -%>
+  <meta name="google-site-verification" content="<%= googleWebmasterMeta %>" />
+<% } -%>
   <meta name="description" content="<%= description %>">
   <meta name="author" content="Joe McCann">
   <%- include style %>


### PR DESCRIPTION
A google-site-verification meta tag for Google Webmaster Tools is hard
coded into the code.  this content key  may not be expected behavior
for other developers who are cloning or using the site.

To fix, a popular configuration library called rc was added.  A basic
starter configuration file for the project was created and the
google-site-verification content option was moved from the hard coded
location in app.js to the config file.
EJS was also adjusted to optionally display this tag as needed.

If desired, the configuration enhancement can also be used for other
configuration requirements.
