### PR TITLE
Fix issues with mixins.styl (issues 115 and 120)

### DIFF
--- a/public/css/mixins.styl
+++ b/public/css/mixins.styl
@@ -584,7 +584,6 @@ normTransition(transition)
   transition: transition
 
 normTransitionMulti(s)
-str = s.replace("'", "")
   -webkit-transition: str
   -moz-transition: str
   -ms-transition: str


### PR DESCRIPTION
I've removed the line that caused the ParseError in stylus. I've removed it because:
- It was causing issues (see 115 and 120)
- The mixin that the line contains is not used anywhere that I could find (grep -nr normTransitionMulti*) so it shouldn't even affect anything else
- I don't know stylus, but that line seems very strange to me (especially the lack of indentation at the beginning)

Maybe a cleaner fix from someone who knows stylus and who can understand what's actually going would be better, but at least this gets it running.
