### PR TITLE
Limit express dependancy to lt version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
-    "express": ">=3.0.0rc3",
+    "express": ">=3.0.0rc3 <4.0.0",
     "rc": "0.3.0",
     "stylus": ">=0.28.2",
     "ejs": ">=0.8.1",


### PR DESCRIPTION
express up to version 3.5.1 works perfectly, but in 4.0 beta support
for configure() was dropped. This commit fixes this dependency.
