### PR TITLE
Do not allow express 4, as dillinger is not compatible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
-    "express": ">=3.0.0rc3",
+    "express": "~3.0.0",
     "rc": "0.3.0",
     "stylus": ">=0.28.2",
     "ejs": ">=0.8.1",


### PR DESCRIPTION
Otherwise you would get the following error when trying to launch the app:

``` bash
app.configure(function(){
    ^
TypeError: Object function (req, res, next) {
    app.handle(req, res, next);
  } has no method 'configure'
    at Object.<anonymous> (/Users/crohr/dev/dillinger/app.js:15:5)
```
