### PR TITLE
made blockquote font sizes same as regular text

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -620,7 +620,7 @@ blockquote {
 }
 blockquote p {
   margin-bottom: 0;
-  font-size: 16px;
+  /*font-size: 16px;*/
   font-weight: 300;
   line-height: 22.5px;
 }


### PR DESCRIPTION
This baby style change makes block quotes have the same font size as regular text, which is how GitHub styles things as well.

Ref: #172
