### PR TITLE
Added very simple Grunt configuration to check ONLY app.js at this stage...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,24 @@
+module.exports = function(grunt) {
+  // Project configuration.
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    jslint: {
+      server: {
+        src: ['app.js'],
+        directives: {
+          indent: 2,
+          node: true,
+          white: true,
+          sloppy: true,
+          nomen: true
+        }
+      }
+    }
+  });
+
+  // Load the plugin that provides the "uglify" task.
+  grunt.loadNpmTasks('grunt-jslint');
+
+  // Default task(s).
+  grunt.registerTask('default', ['jslint']);
+};

--- a/app.js
+++ b/app.js
@@ -1,91 +1,91 @@
-
+/*jslint stupid: true */
 /**
  * Module dependencies.
  */
 
-var config = require('./config')();
-var express = require('express')
+var config = require('./config')()
+  , express = require('express')
   , routes = require('./routes')
   , http = require('http')
   , path = require('path')
   , fs = require('fs')
-
-var app = express()
+  , app = express();
 
 app.configure(function(){
-  app.set('port', process.env.PORT || 8080)
-  app.set('views', __dirname + '/views')
-  app.set('view engine', 'ejs')
-  app.use(express.favicon())
-  app.use(express.logger('dev'))
-  app.use(express.compress())
-  app.use(express.bodyParser())
-  app.use(express.methodOverride())
-  app.use(express.cookieParser('your secret here'))
-  app.use(express.cookieSession())
-  app.use(app.router)
-  app.use(require('stylus').middleware(__dirname + '/public'))
-  app.use(express.static(path.join(__dirname, 'public')))
+  app.set('port', process.env.PORT || 8080);
+  app.set('views', __dirname + '/views');
+  app.set('view engine', 'ejs');
+  app.use(express.favicon());
+  app.use(express.logger('dev'));
+  app.use(express.compress());
+  app.use(express.bodyParser());
+  app.use(express.methodOverride());
+  app.use(express.cookieParser('your secret here'));
+  app.use(express.cookieSession());
+  app.use(app.router);
+  app.use(require('stylus').middleware(__dirname + '/public'));
+  app.use(express.static(path.join(__dirname, 'public')));
 
   // Setup local variables to be available in the views.
-  app.locals.title = config.title || "Dillinger."
-  app.locals.description = config.description || "Dillinger, the last Markdown Editor, ever."
-  if (config.googleWebmasterMeta)
+  app.locals.title = config.title || "Dillinger.";
+  app.locals.description = config.description || "Dillinger, the last Markdown Editor, ever.";
+  if (config.googleWebmasterMeta) {
     app.locals.googleWebmasterMeta = config.googleWebmasterMeta;
-  app.locals.node_version = process.version.replace('v', '')
-  app.locals.app_version = require('./package.json').version
-  app.locals.env = process.env.NODE_ENV
-  app.locals.readme = fs.readFileSync(path.resolve(__dirname, './README.md'), 'utf-8')
-})
+  }
+  app.locals.node_version = process.version.replace('v', '');
+  app.locals.app_version = require('./package.json').version;
+  app.locals.env = process.env.NODE_ENV;
+  app.locals.readme = fs.readFileSync(path.resolve(__dirname, './README.md'), 'utf-8');
+});
 
 app.configure('development', function(){
-  app.use(express.errorHandler())
-})
+  app.use(express.errorHandler());
+});
 
-app.get('/', routes.index)
+app.get('/', routes.index);
 
-app.get('/not-implemented', routes.not_implemented)
+app.get('/not-implemented', routes.not_implemented);
 
 /* Begin Dropbox */
 
-app.get('/redirect/dropbox', routes.oauth_dropbox_redirect)
+app.get('/redirect/dropbox', routes.oauth_dropbox_redirect);
 
-app.get('/oauth/dropbox', routes.oauth_dropbox)
+app.get('/oauth/dropbox', routes.oauth_dropbox);
 
-app.get('/unlink/dropbox', routes.unlink_dropbox)
+app.get('/unlink/dropbox', routes.unlink_dropbox);
 
-app.get('/import/dropbox', routes.import_dropbox)
+app.get('/import/dropbox', routes.import_dropbox);
 
 // app.get('/account/dropbox', routes.account_info_dropbox)
 
-app.post('/fetch/dropbox', routes.fetch_dropbox_file)
+app.post('/fetch/dropbox', routes.fetch_dropbox_file);
 
-app.post('/save/dropbox', routes.save_dropbox)
+app.post('/save/dropbox', routes.save_dropbox);
 
 
 /* End Dropbox */
 
 /* Begin Github */
 
-app.get('/redirect/github', routes.oauth_github_redirect)
+app.get('/redirect/github', routes.oauth_github_redirect);
 
-app.get('/oauth/github', routes.oauth_github)
+app.get('/oauth/github', routes.oauth_github);
 
-app.get('/unlink/github', routes.unlink_github)
+app.get('/unlink/github', routes.unlink_github);
 
 // app.get('/account/github', routes.account_info_github)
 
-app.post('/import/github/orgs', routes.import_github_orgs)
+app.post('/import/github/orgs', routes.import_github_orgs);
 
-app.post('/import/github/repos', routes.import_github_repos)
+app.post('/import/github/repos', routes.import_github_repos);
 
-app.post('/import/github/branches', routes.import_github_branches)
+app.post('/import/github/branches', routes.import_github_branches);
 
-app.post('/import/github/tree_files', routes.import_tree_files)
+app.post('/import/github/tree_files', routes.import_tree_files);
 
-app.post('/import/github/file', routes.import_github_file)
+app.post('/import/github/file', routes.import_github_file);
 
-app.post('/save/github', routes.save_github)
+app.post('/save/github', routes.save_github);
 
 /* End Github */
 
@@ -109,29 +109,29 @@ app.post('/save/googledrive', routes.save_googledrive);
 /* Dillinger Actions */
 
 // save a markdown file and send header to download it directly as response
-app.post('/factory/fetch_markdown', routes.fetch_md)
+app.post('/factory/fetch_markdown', routes.fetch_md);
 
 // Route to handle download of md file
-app.get('/files/md/:mdid', routes.download_md)
+app.get('/files/md/:mdid', routes.download_md);
 
 // Save an html file and send header to download it directly as response
-app.post('/factory/fetch_html', routes.fetch_html)
+app.post('/factory/fetch_html', routes.fetch_html);
 
-app.post('/factory/fetch_html_direct', routes.fetch_html_direct)
+app.post('/factory/fetch_html_direct', routes.fetch_html_direct);
 
 // Route to handle download of html file
-app.get('/files/html/:html', routes.download_html)
+app.get('/files/html/:html', routes.download_html);
 
 // Save a pdf file and send header to download it directly as response
-app.post('/factory/fetch_pdf', routes.fetch_pdf)
+app.post('/factory/fetch_pdf', routes.fetch_pdf);
 
 // Route to handle download of pdf file
-app.get('/files/pdf/:pdf', routes.download_pdf)
+app.get('/files/pdf/:pdf', routes.download_pdf);
 
 /* End Dillinger Actions */
 
 
 http.createServer(app).listen(app.get('port'), function(){
-  console.log("Express server listening on port " + app.get('port'))
-  console.log("\nhttp://localhost:" + app.get('port') + "\n")
-})
+  console.log("Express server listening on port " + app.get('port'));
+  console.log("\nhttp://localhost:" + app.get('port') + "\n");
+});

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   },
   "devDependencies": {
     "smoosh": ">=0.3.2",
-    "walkdir": ">=0.0.5"
+    "walkdir": ">=0.0.5",
+    "grunt": "^0.4.4",
+    "grunt-jslint": "^1.1.11"
   },
   "subdomain": "dill",
   "domains": [


### PR DESCRIPTION
Initial changes to fix "[More consistency in code #158](https://github.com/joemccann/dillinger/issues/158)". In order to implement full consistency however all files will need to be added.

To use, make sure that you have [grunt-cli](https://www.npmjs.org/package/grunt-cli) installed as global

```
npm install -g grunt-cli
```

Then type `grunt` from the terminal.

The current jslint options being used are:

``` JavaScript
indent: 2,    // Indentation should be 2 spaces.
node: true,   // Expect code to be run in node
white: true,  // Don't worry about white space being exactly as per
              // what jslint would normally expect
sloppy: true, // Don't expect "use strict"; pragma
nomen: true   // Allow initial or trailing underscore characters on
              // identifiers
```

At this time, the only file being checked is app.js but if the options are OK then we add in the other files in the project as well.
