### PR TITLE
Fix ShowHTML, fix bool arguments to saveFile

### DIFF
--- a/public/css/custom.styl
+++ b/public/css/custom.styl
@@ -84,6 +84,8 @@ https://github.com/joemccann/dillinger/issues/126
 
 #filename-counter-container > #wordcounter
   width 18.5%
+  /* floating this right fixes some rendering issues in SOME smaller viewports - not a fixall though */
+  float:right
 
 #filename-counter-container > #filename > span, #wordcounter
   font-size: 16px


### PR DESCRIPTION
Fixes #152 by removing custom modal dialog and using the generic modal like the rest of the application - commented out functionality will be cleaned up in the next commit (oops).

Modifies boolean arguments being passed to saveFile as discussed in #182 and recommended by @swang

Small css fix adding float to word count box as a quickfix in some smaller width viewports
