### PR TITLE
Revert core sanitize to false for exports, front-end sanitize true

### DIFF
--- a/plugins/core/core.js
+++ b/plugins/core/core.js
@@ -11,7 +11,7 @@ markdown.setOptions({
   tables: true,
   breaks: false,
   pedantic: false,
-  sanitize: true,
+  sanitize: false,
   smartLists: true,
   smartypants: false,
   highlighter: function(code) {

--- a/public/js/dillinger.js
+++ b/public/js/dillinger.js
@@ -297,7 +297,7 @@ $(function() {
         gfm: true
       , tables: true
       , pedantic: false
-      , sanitize: false
+      , sanitize: true
       , smartLists: true
       , smartypants: false
       , langPrefix: 'lang-'


### PR DESCRIPTION
Sanitize option in core for export operations results in raw HTML output like:

```
<p>&lt;a href=&quot;coolplace.html&quot;&gt;CoolPlace&lt;/a&gt;</p>
```

Reverting the setting to false should fix this.  

Setting sanitize option true for marked for front-end rendering prevents raw html script execution.  For now we should just see this as a minor security tradeoff until we can tackle an inline renderer that will handle raw script blocks directly in our rendered output. 
