### PR TITLE
Remove lodash, unused module

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "ejs": ">=0.8.1",
     "request": ">=2.9.203",
     "colors": ">=0.6.0-1",
-    "lodash": ">=0.6.1",
     "dbox": "0.6.3",
     "googleapis": "0.2.12-alpha",
     "marked": "^0.3.2",

--- a/plugins/dropbox/dropbox.js
+++ b/plugins/dropbox/dropbox.js
@@ -4,7 +4,6 @@ var fs = require('fs')
   , dbox = require('dbox')
   , qs = require('querystring')
   , url = require('url')
-  , _ = require('lodash')
 
 var dropbox_config_file = path.resolve(__dirname, 'dropbox-config.json')
   , dropbox_config = {}


### PR DESCRIPTION
I don't see this used anywhere, so it's just extraneous bytes
