### PR TITLE
Bug fix

### DIFF
--- a/public/js/plugins/github/github.controller.js
+++ b/public/js/plugins/github/github.controller.js
@@ -68,9 +68,10 @@ module.exports =
 
     // Document must be an importet file from Github to work.
     if (file.isGithubFile) {
+      var filePath = file.github.path.substr(0,file.github.path.lastIndexOf('/'));
       var postData = {
         body:    file.body,
-        path:    file.github.path.substr(0,file.github.path.lastIndexOf('/')) + '/' + file.title,
+        path:    filePath ? filePath + '/' + file.title : file.title,
         sha:     file.github.sha,
         branch:  file.github.branch,
         repo:    file.github.repo,


### PR DESCRIPTION
Fixed bug that prevented saving a file at the root of a github repository. A file at the root was prefixed with '/', which github does not allow. Github was returning 400 with response body of {"error":"Unable to save file: path cannot start with a slash"}