### PR TITLE
Working Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,18 +46,18 @@ RUN command -v node >/dev/null 2>&1 || { ln -s /usr/bin/nodejs /usr/bin/node; }
 RUN npm install -g gulp forever
 
 #
+# application environment variables
+# change the port here and elsehwere
+#
+ENV PORT=80
+ENV NODE_ENV=production
+
+#
 # install the app
 #
 RUN mkdir -p /opt/install/dillinger && mkdir -p /opt/install/dillinger/public/files/{md,html,pdf}
 ADD . /opt/install/dillinger
 RUN cd /opt/install/dillinger && gulp build --prod
-
-#
-# environment variables
-# change the port here and elsehwere
-#
-ENV PORT=80
-ENV NODE_ENV=production
 
 #
 # port 80 exposed by default, can be overridden with -p machine:container
@@ -68,3 +68,7 @@ expose 80
 # light this candle
 #
 CMD ["forever", "/opt/install/dillinger/app.js"]
+
+#
+# `docker run` example:
+# docker run -d -p 80:80 -e 'PORT=80' -e 'NODE_ENV=production' misterbisson/dillinger

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,12 @@ RUN mkdir -p \
     mv /tmp/node_modules /opt/install/dillinger/.
 ADD . /opt/install/dillinger
 RUN cd /opt/install/dillinger && \
-    gulp build --prod
+    npm i -d
+
+# The following is disabled because of https://github.com/joemccann/dillinger/issues/309
+# RUN cd /opt/install/dillinger && \
+#    npm i -d && \
+#    gulp build --prod
 
 #
 # running on port 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ RUN npm install -g gulp forever
 # using caching suggestions per http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/
 #
 ADD ./package.json /tmp/package.json
-RUN cd /tmp && npm install
+RUN cd /tmp && \
+    npm install
 
 #
 # application environment variables
@@ -67,7 +68,8 @@ RUN mkdir -p \
     mkdir -p /opt/install/dillinger/public/files/{md,html,pdf} && \
     mv /tmp/node_modules /opt/install/dillinger/.
 ADD . /opt/install/dillinger
-RUN gulp build --prod
+RUN cd /opt/install/dillinger && \
+    gulp build --prod
 
 #
 # running on port 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,15 @@ RUN command -v node >/dev/null 2>&1 || { ln -s /usr/bin/nodejs /usr/bin/node; }
 RUN npm install -g gulp forever
 
 #
+# install the node dependencies for our node server app
+# using caching suggestions per http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/
+#
+ADD ./package.json /tmp/package.json
+RUN cd /tmp && npm install
+
+#
 # application environment variables
-# change the port here and elsehwere
+# change the port here and elsewhere
 #
 ENV PORT=80
 ENV NODE_ENV=production
@@ -55,12 +62,16 @@ ENV NODE_ENV=production
 #
 # install the app
 #
-RUN mkdir -p /opt/install/dillinger && mkdir -p /opt/install/dillinger/public/files/{md,html,pdf}
+RUN mkdir -p \
+    /opt/install/dillinger && \
+    mkdir -p /opt/install/dillinger/public/files/{md,html,pdf} && \
+    mv /tmp/node_modules /opt/install/dillinger/.
 ADD . /opt/install/dillinger
-RUN cd /opt/install/dillinger && gulp build --prod
+RUN gulp build --prod
 
 #
-# port 80 exposed by default, can be overridden with -p machine:container
+# running on port 80
+# change the port here and elsehwere
 #
 expose 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # Installs dillinger on a container
 #
 # VERSION  0.0.0
-from       ubuntu:14.04
-maintainer Nuno Job "nunojobpinto@gmail.com"
-maintainer Casey Bisson "casey.bisson@gmail.com"
+FROM ubuntu:14.04
+MAINTAINER Nuno Job "nunojobpinto@gmail.com"
+MAINTAINER Casey Bisson "casey.bisson@gmail.com"
 
 #
 # update apt
@@ -88,5 +88,8 @@ expose 80
 CMD ["forever", "/opt/install/dillinger/app.js"]
 
 #
+# `docker build` example:
+# sudo docker build -t joemccann/dillinger .
+#
 # `docker run` example:
-# docker run -d -p 80:80 -e 'PORT=80' -e 'NODE_ENV=production' misterbisson/dillinger
+# docker run -d -p 80:80 joemccann/dillinger

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "angular": "^1.3.0",
-    "angular-bootstrap": "^0.11.0",
+    "angular-bootstrap": "^0.12.0",
     "brace": "^0.4.0",
     "colors": ">=1.0.3",
     "dbox": "0.6.3",


### PR DESCRIPTION
This updates the Docker file as needed to produce a (mostly) working app.

- Build: `sudo docker build -t joemccann/dillinger .`
- Run: `docker run -d -p 80:80 joemccann/dillinger`

Some things that I discovered about Dillinger beyond the Dockerfile:

- I upped the angular-boostrap version in package.json per #296
- Setting `NODE_ENV=production` _before_ the npm install steps will cause the later `gulp build --prod` to fail due to missing dependencies. Perhaps some of the devDependencies in package.json should be moved to full dependencies?
- I implemented a lazy workaround suggested in https://github.com/joemccann/dillinger/issues/309#issuecomment-81779702, though this leaves it without working integrations. I'm guessing pieces of a requirejs implementation haven't been committed?

Changes in the Dockerfile:

- Updated for changes in app requirements, apt packages, and Dockerfile practice.
- Broke some pieces into multiple lines so we can more easily see changes going forward.
- Separated the module fetching from the app installation so we can take advantage of layer caching for faster build times. See http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/ for background.
- This now defaults to accept connections on port 80, though that can be easily changed by changing the `-p 80:80` args. I'm happy to change this, but it seemed better to have the container use the more common port 80 by default, and use Docker args to change it.