### PR TITLE
Added modified date to google drive to differentiate files with the same name

### DIFF
--- a/public/js/plugins/google-drive/google-drive-modal.directive.html
+++ b/public/js/plugins/google-drive/google-drive-modal.directive.html
@@ -20,6 +20,7 @@
   <ul>
     <li ng-repeat="file in modal.paginatedFiles | startFrom: (modal.currentPage-1) * modal.itemsPerPage | limitTo: modal.itemsPerPage">
       <a ng-bind="file.title" ng-click="modal.fetchFile(file.id)"></a>
+      <span ng-bind="file.modifiedDate | date:'short'"></span>
     </li>
   </ul>
 


### PR DESCRIPTION
Google drive is allowing the saving of files with the same name which makes it difficult to differentiate

![google-drive-multiple-entries](https://cloud.githubusercontent.com/assets/1111211/8767689/96ac83cc-2e5c-11e5-9240-e2d41a82ad04.png)

I propose adding the last modified date to allow identification of files

![google-drive-multiple-entries-with-date](https://cloud.githubusercontent.com/assets/1111211/8767696/ca118adc-2e5c-11e5-992e-5481f619aac5.png)

