### PR TITLE
Fix outdated copyright year (update to 2015)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2014 Joe McCann
+Copyright (c) 2011-2015 Joe McCann
 
 All rights reserved.
 


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2015.