### PR TITLE
Corrected the Markdown used in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dillinger is a cloud-enabled, mobile-ready, offline-storage, AngularJS powered H
   - See HTML in the right
   - Magic
 
-Markdown is a lightweight markup language based on the formatting conventions that people naturally use in email.  As [John Gruber] writes on the [Markdown site] [1]:
+Markdown is a lightweight markup language based on the formatting conventions that people naturally use in email.  As [John Gruber] writes on the [Markdown site][df1]
 
 > The overriding design goal for Markdown's
 > formatting syntax is to make it as readable
@@ -35,7 +35,8 @@ Dillinger uses a number of open source projects to work properly:
 * [keymaster.js] - awesome keyboard handler lib by [@thomasfuchs]
 * [jQuery] - duh
 
-And of course Dillinger itself is open source with a [public repository](https://github.com/joemccann/dillinger) on GitHub.
+And of course Dillinger itself is open source with a [public repository][dill]
+ on GitHub.
 
 ### Installation
 
@@ -65,10 +66,10 @@ Dillinger is currently extended with the following plugins
 
 Readmes, how to use them in your own application can be found here:
 
-* [plugins/dropbox/README.md](https://github.com/joemccann/dillinger/tree/master/plugins/dropbox/README.md)
-* [plugins/github/README.md](https://github.com/joemccann/dillinger/tree/master/plugins/github/README.md)
-* [plugins/googledrive/README.md](https://github.com/joemccann/dillinger/tree/master/plugins/googledrive/README.md)
-* [plugins/onedrive/README.md](https://github.com/joemccann/dillinger/tree/master/plugins/onedrive/README.md)
+* [plugins/dropbox/README.md] [PlDb]
+* [plugins/github/README.md] [PlGh]
+* [plugins/googledrive/README.md] [PlGd]
+* [plugins/onedrive/README.md] [PlOd]
 
 ### Development
 
@@ -109,16 +110,28 @@ MIT
 
 **Free Software, Hell Yeah!**
 
-- [john gruber](http://daringfireball.net)
-- [@thomasfuchs](http://twitter.com/thomasfuchs)
-- [1](http://daringfireball.net/projects/markdown/)
-- [marked](https://github.com/chjj/marked)
-- [Ace Editor](http://ace.ajax.org)
-- [node.js](http://nodejs.org)
-- [Twitter Bootstrap](http://twitter.github.com/bootstrap/)
-- [keymaster.js](https://github.com/madrobby/keymaster)
-- [jQuery](http://jquery.com)
-- [@tjholowaychuk](http://twitter.com/tjholowaychuk)
-- [express](http://expressjs.com)
-- [AngularJS](http://angularjs.org)
-- [Gulp](http://gulpjs.com)
+[//]: # (These are reference links used in the body of this note and get stripped out when the markdown processor does it's job. There is no need to format nicely because it shouldn't be seen. Thanks SO - http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax)
+
+
+   [dill]: <https://github.com/joemccann/dillinger>
+   [git-repo-url]: <https://github.com/joemccann/dillinger.git>
+   [john gruber]: <http://daringfireball.net>
+   [@thomasfuchs]: <http://twitter.com/thomasfuchs>
+   [df1]: <http://daringfireball.net/projects/markdown/>
+   [marked]: <https://github.com/chjj/marked>
+   [Ace Editor]: <http://ace.ajax.org>
+   [node.js]: <http://nodejs.org>
+   [Twitter Bootstrap]: <http://twitter.github.com/bootstrap/>
+   [keymaster.js]: <https://github.com/madrobby/keymaster>
+   [jQuery]: <http://jquery.com>
+   [@tjholowaychuk]: <http://twitter.com/tjholowaychuk>
+   [express]: <http://expressjs.com>
+   [AngularJS]: <http://angularjs.org>
+   [Gulp]: <http://gulpjs.com>
+   
+   [PlDb]: <https://github.com/joemccann/dillinger/tree/master/plugins/dropbox/README.md>
+   [PlGh]:  <https://github.com/joemccann/dillinger/tree/master/plugins/github/README.md>
+   [PlGd]: <https://github.com/joemccann/dillinger/tree/master/plugins/googledrive/README.md>
+   [PlOd]: <https://github.com/joemccann/dillinger/tree/master/plugins/onedrive/README.md>
+
+


### PR DESCRIPTION
## Corrected the markdown in the README.md file

The links are now all by reference and not inline. According to the [syntax page][links] it makes markdown even more readable.

Added a comment above the reference link data to the effect that it should not and now does not display on the rendered page.

Changed the parenthesis to angle brackets for the URLs. They cause a corruption of the URL, prepending dillinger.io/ to each URL.

now - http://expressjs.com/
with parentheses - http://dillinger.io/(http://expressjs.com)


 [links]: <http://daringfireball.net/projects/markdown/syntax#link>
