### PR TITLE
(feat) fixed editor / preview header 

### DIFF
--- a/public/scss/components/_zen-mode.scss
+++ b/public/scss/components/_zen-mode.scss
@@ -33,7 +33,7 @@
   display: block;
   position: absolute;
   right: .5rem;
-  top: .5rem;
+  top: .313rem;
   display: none;
 
   @include from('tablet') {

--- a/public/scss/structures/_ace_editor.scss
+++ b/public/scss/structures/_ace_editor.scss
@@ -45,3 +45,26 @@
   }
 
 }
+
+.editor-header {
+  width: 50%;
+  float: left;
+  border-bottom: 1px solid $c-border;
+  position: relative;
+
+  @include to('tablet') {
+    display: none;
+  }
+
+  &--first {
+    border-right: 1px solid $c-border;
+    @include to('tablet') {
+      display: block;
+      width: 100%;
+    }
+  }
+
+  .title {
+    display: inline-block;
+  }
+}

--- a/public/scss/structures/_split.scss
+++ b/public/scss/structures/_split.scss
@@ -52,7 +52,7 @@
     @include from('tablet') {
       border-right: 1px solid $c-border;
       float: left;
-      height: calc(100vh - 130px);
+      height: calc(100vh - 172px);
       -webkit-overflow-scrolling: touch;
       padding-right: 16px;
       width: 50%;
@@ -77,7 +77,7 @@
     @include from('tablet') {
       display: block;
       float: right;
-      height: calc(100vh - 130px);
+      height: calc(100vh - 172px);
       -webkit-overflow-scrolling: touch;
       position: relative;
       top: 0;

--- a/views/editor-headers.ejs
+++ b/views/editor-headers.ejs
@@ -1,0 +1,7 @@
+<div class="editor-header editor-header--first">
+  <h3 class="title">Markdown</h3>
+  <toggle-zen-mode></toggle-zen-mode>
+</div>
+<div class="editor-header">
+  <h3 class="title">Preview</h3>
+</div>

--- a/views/editor.ejs
+++ b/views/editor.ejs
@@ -1,5 +1,3 @@
 <div class="g-b g-b--t1of2 split split-editor">
-  <h3 class="title">Markdown</h3>
-  <toggle-zen-mode></toggle-zen-mode>
   <div id="editor"></div>
 </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -62,6 +62,7 @@
       <%- include overlay %>
       <%- include title %>
       <div class="g mnone">
+        <%- include editor-headers %>
         <%- include editor %>
         <%- include preview %>
       </div>

--- a/views/preview.ejs
+++ b/views/preview.ejs
@@ -1,4 +1,3 @@
 <div class="g-b g-b--t1of2 split split-preview">
-  <h3 class="title">Preview</h3>
   <div id="preview" preview></div>
 </div>


### PR DESCRIPTION
As mentioned in #478, the editor header will remain fixed to the top of the editor, this allows for 'Zen' mode to be engaged easily. For consistency purposes the preview header is also fixed.

