### PR TITLE
debounce editor change events 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Dillinger",
   "description": "Dillinger, the last Markdown editor you'll ever need, by your's truly, Joe McCann.",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "author": {
     "name": "Joe McCann",
     "email": "joe@nodesource.com"

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -24,6 +24,7 @@
   require('./components/preview.directive');
 
   require('./components/wtfisdillinger-modal.controller');
+  require('./services/debounce.service');
 
   // User
   require('./user/user.controller');
@@ -75,7 +76,8 @@
     'plugins.dropbox',
     'plugins.googledrive',
     'plugins.onedrive',
-    'ui.bootstrap'
+    'ui.bootstrap',
+    'diDebounce.service'
   ]);
 
   // Run!

--- a/public/js/components/preview.directive.js
+++ b/public/js/components/preview.directive.js
@@ -1,23 +1,24 @@
 
 'use strict';
 
-var md = require( 'md' ).md
-
+var md = require( 'md' ).md;
 
 module.exports =
   angular
   .module('diBase.directives.preview', [])
-  .directive('preview', function($rootScope) {
+  .directive('preview', function($rootScope, debounce) {
 
   var directive = {
     link: function(scope, el, attrs) {
+
+      var delay = attrs.debounce || 200;
 
       var refreshPreview = function(val) {
         el.html(md.render($rootScope.editor.getSession().getValue()));
         return $rootScope.$emit('preview.updated');
       };
 
-      $rootScope.editor.on('change', refreshPreview);
+      $rootScope.editor.on('change', debounce(refreshPreview, delay));
 
       return refreshPreview();
     }

--- a/public/js/documents/documents.controller.js
+++ b/public/js/documents/documents.controller.js
@@ -6,7 +6,7 @@ module.exports =
     'diDocuments.service',
     'diDocuments.export'
   ])
-  .controller('Documents', function($scope, $timeout, $rootScope, userService, documentsService) {
+  .controller('Documents', function($scope, $timeout, $rootScope, userService, documentsService, debounce) {
 
   var vm = this;
 
@@ -25,7 +25,7 @@ module.exports =
 
   $rootScope.documents = documentsService.getItems();
 
-  $rootScope.editor.on('change', doAutoSave);
+  $rootScope.editor.on('change', debounce(doAutoSave, 5000));
   $rootScope.$on('autosave', doAutoSave);
 
   function save(manuel) {

--- a/public/js/services/debounce.service.js
+++ b/public/js/services/debounce.service.js
@@ -1,0 +1,29 @@
+
+'use strict';
+module.exports =
+  angular
+  .module('diDebounce.service', [])
+  .factory('debounce', function($timeout) {
+
+    return debounce;
+
+    function debounce(cb, delay) {
+      var timer;
+
+      return function() {
+        var context = this;
+        var args = arguments;
+
+        // create a function that will clear the timer and call
+        // the original callback function
+        var later = function() {
+          timer = null;
+          cb.apply(context, args);
+        };
+
+        $timeout.cancel(timer);
+        timer = $timeout(later, delay);
+      };
+    }
+
+  });

--- a/views/preview.ejs
+++ b/views/preview.ejs
@@ -1,3 +1,3 @@
 <div class="g-b g-b--t1of2 split split-preview">
-  <div id="preview" preview></div>
+  <div id="preview" preview debounce="150"></div>
 </div>


### PR DESCRIPTION
As mentioned in #491 when the live preview is on the app can feel slow when editing a large document.

I have created a factory that will debounce an event, that can be used throughout the app. I debounced the render function but I also noticed that the __save__ function was being executed after every single change to the editor. I also debounced this but with a much longer timer (5 seconds) as the operation happens in the background.
