### PR TITLE
Editor style in zen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ $ npm i -g gulp
 $ git clone [git-repo-url] dillinger
 $ cd dillinger
 $ npm i -d
-$ mkdir -p downloads/files/{md,html,pdf}
 $ gulp build --prod
 $ NODE_ENV=production node app
 ```
@@ -136,7 +135,7 @@ MIT
    [express]: <http://expressjs.com>
    [AngularJS]: <http://angularjs.org>
    [Gulp]: <http://gulpjs.com>
-   
+
    [PlDb]: <https://github.com/joemccann/dillinger/tree/master/plugins/dropbox/README.md>
    [PlGh]:  <https://github.com/joemccann/dillinger/tree/master/plugins/github/README.md>
    [PlGd]: <https://github.com/joemccann/dillinger/tree/master/plugins/googledrive/README.md>

--- a/public/js/zen-mode/zen-mode.controller.js
+++ b/public/js/zen-mode/zen-mode.controller.js
@@ -41,6 +41,8 @@ module.exports =
       require('../documents/theme-dillinger');
 
       vm.zen = ace.edit('zen');
+      vm.zen.getSession().setMode('ace/mode/markdown');
+      vm.zen.setTheme('ace/theme/dillinger');
       vm.zen.getSession().setUseWrapMode(true);
       vm.zen.renderer.setShowGutter(false);
       vm.zen.setShowPrintMargin(false);


### PR DESCRIPTION
I have added style and mode to zen mode editor settings as it mentioned in #495. Also i have pruned outdated line from documentation `mkdir -p downloads/files/{md,html,pdf} `, these folders will be downloaded automatically since there are `.gitkeep` files.

Closes: #495.