### PR TITLE
Fixed problem with dockerfile and amended README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@
 #
 # Installs dillinger on a container
 #
-# VERSION  1.0.0
+# VERSION  1.0.1
 
-FROM nodesource/nsolid-node	
+FROM nodesource/nsolid	
 MAINTAINER Joe McCann "joe@nodesource.com"
 MAINTAINER William Blankenship "william.jblankenship@gmail.com"
-
+MAINTAINER Steve Jones "stephen.j.jones@uea.ac.uk"
 #
 # install the node dependencies for our node server app
 # using caching suggestions per http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/

--- a/README.md
+++ b/README.md
@@ -94,7 +94,24 @@ $ gulp watch
 $ karma start
 ```
 
-### Docker, N|Solid and NGINX
+### Docker
+Dillinger is very easy to install and deploy in a Docker container.
+
+By default, the Docker will expose port 80, so change this within the Dockerfile if necessary. When ready, simply use the Dockerfile to build the image. 
+
+```sh
+cd dillinger
+docker build -t <youruser>/dillinger:latest .
+```
+This will create the dillinger image and pull in the necessary dependencies. Once done, run the Docker and map the port to whatever you wish on your host. In this example, we simply map port 80 of the host to port 80 of the Docker (or whatever port was exposed in the Dockerfile):
+
+```sh
+docker run -d -p 80:80 --restart="always" <youruser>/dillinger:latest
+```
+
+Verify the deployment by navigating to your server address in your preferred browser.
+
+### N|Solid and NGINX
 
 More details coming soon.
 
@@ -140,5 +157,4 @@ MIT
    [PlGh]:  <https://github.com/joemccann/dillinger/tree/master/plugins/github/README.md>
    [PlGd]: <https://github.com/joemccann/dillinger/tree/master/plugins/googledrive/README.md>
    [PlOd]: <https://github.com/joemccann/dillinger/tree/master/plugins/onedrive/README.md>
-
 


### PR DESCRIPTION
Forgive me as a novice in all things github and Docker, but wanted to use dillinger within a Docker for my own learning purposes.

nodesource/nsolid-node wasn't found and caused the build to fail. I noticed that this wasn't present on dockerhub, so have amended the dockerfile and have been able to successfully build and deploy, albeit with a few deprecation warnings.

I've also added in some info within the docker section on the readme.