### PR TITLE
gulp watch should update javascript

### DIFF
--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -8,7 +8,7 @@ var
 gulp.task('browserSync', function() {
   browserSync({
     files: ['views/**'],
-    proxy: 'localhost:8080',
+    proxy: 'localhost:8090',
     notify: false
   });
 });

--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -24,8 +24,13 @@ gulp.task('webpack:dev', function(cb) {
   devCompiler = webpack(webpackDevConfig);
 
   return new webpackDevServer(devCompiler, {
-    contentBase: 'http://localhost:8080/',
-    publicPath:  'http://localhost:8090/assets/',
+    proxy: {
+      '*': {
+        target: 'http://localhost:8080',
+        secure: false,
+      },
+    },
+    publicPath:  'http://localhost:8090/js/',
     hot:         false,
     stats: {
       colors: true


### PR DESCRIPTION
gulp watch was not updating the javascript when changed and required grunt build.
webpack-dev-server was configured to run on port 8090 with public path was set to assets rather than js.  
browserSync was configured to proxy to port 8080 so it was only ever serving the prebuilt bundle.js if there was one otherwise it would return 404.  
