### PR TITLE
Adds user confirmation before deleting documents

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -35,6 +35,7 @@
   require('./services/documents.service');
   require('./documents/documents-export.controller');
   require('./documents/documents.controller');
+  require('./documents/delete-modal.controller');
   require('./services/wordscount.service');
 
   // Plugin: Github

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -22,6 +22,7 @@
   require('./components/toggle-preview.directive');
   require('./components/switch.directive');
   require('./components/preview.directive');
+  require('./components/focus.factory');
 
   require('./components/wtfisdillinger-modal.controller');
   require('./services/debounce.service');

--- a/public/js/components/focus.factory.js
+++ b/public/js/components/focus.factory.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports =
+  angular
+  .module('diBase.factories', [])
+  .factory('focus', function($timeout, $window) {
+   return function(id) {
+     // timeout makes sure that it is invoked after any other event has been triggered.
+     // e.g. click events that need to run before the focus or
+     // inputs elements that are in a disabled state but are enabled when those events
+     // are triggered.
+     $timeout(function() {
+       var element = $window.document.getElementById(id);
+       if(element) {
+         element.focus();
+       }
+     });
+   };
+ });

--- a/public/js/documents/delete-modal.controller.js
+++ b/public/js/documents/delete-modal.controller.js
@@ -3,11 +3,29 @@
 
 module.exports =
   angular
-  .module('diDocuments.controllers', [])
-  .controller('DeleteDialog', function($scope, $modalInstance) {
+  .module('diDocuments.controllers', ['diDocuments.service'])
+  .controller('DeleteDialog', function($scope, $modalInstance, $rootScope, $timeout, documentsService) {
+
+  var item = $scope.item;
 
   $scope.ok = function() {
-    $scope.procede();
+    // The version of angular bootstrap we are using
+    // dosen't have the closed promise.
+    // I could update angular bootstrap but I don't think
+    // it's worth potentially introducing regression
+    // for a small delete dialog.
+    $timeout(function() {
+      // WARNING: At this point the $scope was destried
+      // by a previous call to $modalInstance.close().
+      // Once again this could be avoided if we had
+      // an up-to-date version of angular bootstrap.
+      documentsService.removeItem(item);
+      var next = documentsService.getItemByIndex(0);
+      documentsService.setCurrentDocument(next);
+
+      $rootScope.$emit('document.refresh');
+    }, 500);
+
     return $modalInstance.close();
   };
 

--- a/public/js/documents/delete-modal.controller.js
+++ b/public/js/documents/delete-modal.controller.js
@@ -3,8 +3,8 @@
 
 module.exports =
   angular
-  .module('diDocuments.controllers', ['diDocuments.service'])
-  .controller('DeleteDialog', function($scope, $modalInstance, $rootScope, $timeout, documentsService) {
+  .module('diDocuments.controllers', ['diDocuments.service', 'diBase.factories'])
+  .controller('DeleteDialog', function($scope, $modalInstance, $rootScope, $timeout, documentsService, focus) {
 
   var item = $scope.item;
 
@@ -32,5 +32,12 @@ module.exports =
   $scope.cancel = function() {
     return $modalInstance.dismiss('cancel');
   };
+
+  // Set focus on the YES button to allow the user to
+  // press enter or space to confirm deleting and to
+  // visually highlight the YES button.
+  $timeout(function() {
+    focus('deleteModalYes');
+  }, 100);
 
 });

--- a/public/js/documents/delete-modal.controller.js
+++ b/public/js/documents/delete-modal.controller.js
@@ -1,0 +1,18 @@
+
+'use strict';
+
+module.exports =
+  angular
+  .module('diDocuments.controllers', [])
+  .controller('DeleteDialog', function($scope, $modalInstance) {
+
+  $scope.ok = function() {
+    $scope.procede();
+    return $modalInstance.close();
+  };
+
+  $scope.cancel = function() {
+    return $modalInstance.dismiss('cancel');
+  };
+
+});

--- a/public/js/documents/delete-modal.directive.html
+++ b/public/js/documents/delete-modal.directive.html
@@ -9,6 +9,6 @@
   <div>Word cound: {{wordCount}}</div>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn--ok btn--delete-modal" ng-click="ok()">Yes</button>
-  <button type="button" class="btn btn--ok btn--delete-modal" ng-click="cancel()">Cancel</button>
+  <button type="button" class="btn btn--delete-modal" ng-click="ok()">Yes</button>
+  <button type="button" class="btn btn--delete-modal" ng-click="cancel()">Cancel</button>
 </div>

--- a/public/js/documents/delete-modal.directive.html
+++ b/public/js/documents/delete-modal.directive.html
@@ -2,7 +2,7 @@
   <button type="button" class="close" ng-click="cancel()">
     <span aria-hidden="true">&times;</span><span class="sr-only">Close</span>
   </button>
-  <h3>Are you sure you want to delete this file?</h3>
+  <h3>Are you sure you want to delete this document?</h3>
 </div>
 <div class="modal-body">
   <div>{{item.title}}</div>

--- a/public/js/documents/delete-modal.directive.html
+++ b/public/js/documents/delete-modal.directive.html
@@ -1,0 +1,14 @@
+<div class="modal-header">
+  <button type="button" class="close" ng-click="cancel()">
+    <span aria-hidden="true">&times;</span><span class="sr-only">Close</span>
+  </button>
+  <h3>Are you sure you want to delete this file?</h3>
+</div>
+<div class="modal-body">
+  <div>{{title}}</div>
+  <div>Word cound: {{wordCount}}</div>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn--ok btn--delete-modal" ng-click="ok()">Yes</button>
+  <button type="button" class="btn btn--ok btn--delete-modal" ng-click="cancel()">Cancel</button>
+</div>

--- a/public/js/documents/delete-modal.directive.html
+++ b/public/js/documents/delete-modal.directive.html
@@ -5,7 +5,7 @@
   <h3>Are you sure you want to delete this file?</h3>
 </div>
 <div class="modal-body">
-  <div>{{title}}</div>
+  <div>{{item.title}}</div>
   <div>Word cound: {{wordCount}}</div>
 </div>
 <div class="modal-footer">

--- a/public/js/documents/delete-modal.directive.html
+++ b/public/js/documents/delete-modal.directive.html
@@ -9,6 +9,6 @@
   <div>Word cound: {{wordCount}}</div>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn--delete-modal" ng-click="ok()">Yes</button>
+  <button type="button" id='deleteModalYes' class="btn btn--delete-modal" ng-click="ok()">Yes</button>
   <button type="button" class="btn btn--delete-modal" ng-click="cancel()">Cancel</button>
 </div>

--- a/public/js/documents/documents.controller.js
+++ b/public/js/documents/documents.controller.js
@@ -59,18 +59,8 @@ module.exports =
 
   function removeDocument(item) {
     var modalScope = $rootScope.$new();
-    modalScope.title = item.title;
+    modalScope.item = item;
     modalScope.wordCount = wordsCountService.count();
-
-    modalScope.procede = function() {
-      var next;
-
-      documentsService.removeItem(item);
-      next = documentsService.getItemByIndex(0);
-      documentsService.setCurrentDocument(next);
-
-      $rootScope.$emit('document.refresh');
-    };
 
     $modal.open({
       template: require('raw!../documents/delete-modal.directive.html'),

--- a/public/js/documents/documents.controller.js
+++ b/public/js/documents/documents.controller.js
@@ -4,9 +4,10 @@ module.exports =
   angular
   .module('diDocuments', [
     'diDocuments.service',
-    'diDocuments.export'
+    'diDocuments.export',
+    'diDocuments.service.wordcount'
   ])
-  .controller('Documents', function($scope, $timeout, $rootScope, userService, documentsService, debounce) {
+  .controller('Documents', function($scope, $timeout, $rootScope, userService, documentsService, debounce, wordsCountService) {
 
   var vm = this;
 
@@ -55,15 +56,28 @@ module.exports =
     return $rootScope.$emit('document.refresh');
   }
 
+  function deleteConfirmed(item) {
+    return confirm(
+      'Are you sure you want to delete this document?' +
+      '\n' +
+      '\n' +
+      item.title +
+      '\n' +
+      'Word count: ' + wordsCountService.count()
+    );
+  }
+
   function removeDocument(item) {
     var next;
 
-    // The order is important here.
-    documentsService.removeItem(item);
-    next = documentsService.getItemByIndex(0);
-    documentsService.setCurrentDocument(next);
+    if ( deleteConfirmed(item) ) {
+      // The order is important here.
+      documentsService.removeItem(item);
+      next = documentsService.getItemByIndex(0);
+      documentsService.setCurrentDocument(next);
 
-    return $rootScope.$emit('document.refresh');
+      return $rootScope.$emit('document.refresh');
+    }
   }
 
   function createDocument() {

--- a/public/js/documents/documents.controller.js
+++ b/public/js/documents/documents.controller.js
@@ -5,9 +5,10 @@ module.exports =
   .module('diDocuments', [
     'diDocuments.service',
     'diDocuments.export',
+    'diDocuments.controllers',
     'diDocuments.service.wordcount'
   ])
-  .controller('Documents', function($scope, $timeout, $rootScope, userService, documentsService, debounce, wordsCountService) {
+  .controller('Documents', function($scope, $timeout, $rootScope, $modal, userService, documentsService, debounce, wordsCountService) {
 
   var vm = this;
 
@@ -56,28 +57,27 @@ module.exports =
     return $rootScope.$emit('document.refresh');
   }
 
-  function deleteConfirmed(item) {
-    return confirm(
-      'Are you sure you want to delete this document?' +
-      '\n' +
-      '\n' +
-      item.title +
-      '\n' +
-      'Word count: ' + wordsCountService.count()
-    );
-  }
-
   function removeDocument(item) {
-    var next;
+    var modalScope = $rootScope.$new();
+    modalScope.title = item.title;
+    modalScope.wordCount = wordsCountService.count();
 
-    if ( deleteConfirmed(item) ) {
-      // The order is important here.
+    modalScope.procede = function() {
+      var next;
+
       documentsService.removeItem(item);
       next = documentsService.getItemByIndex(0);
       documentsService.setCurrentDocument(next);
 
-      return $rootScope.$emit('document.refresh');
-    }
+      $rootScope.$emit('document.refresh');
+    };
+
+    $modal.open({
+      template: require('raw!../documents/delete-modal.directive.html'),
+      scope: modalScope,
+      controller: 'DeleteDialog',
+      windowClass: 'modal--dillinger about'
+    });
   }
 
   function createDocument() {

--- a/public/js/documents/documents.controller.js
+++ b/public/js/documents/documents.controller.js
@@ -76,7 +76,7 @@ module.exports =
       template: require('raw!../documents/delete-modal.directive.html'),
       scope: modalScope,
       controller: 'DeleteDialog',
-      windowClass: 'modal--dillinger about'
+      windowClass: 'modal--dillinger'
     });
   }
 

--- a/public/scss/components/_buttons.scss
+++ b/public/scss/components/_buttons.scss
@@ -77,6 +77,11 @@
     }
   }
 
+  &--delete-modal {
+    display: inline;
+    width: auto;
+  }
+
   &--ok,
   &--close {
     border-top: 0;

--- a/public/scss/components/_buttons.scss
+++ b/public/scss/components/_buttons.scss
@@ -77,11 +77,7 @@
     }
   }
 
-  &--delete-modal {
-    display: inline;
-    width: auto;
-  }
-
+  &--delete-modal,
   &--ok,
   &--close {
     border-top: 0;
@@ -95,6 +91,11 @@
       background-color: darken($c-button-save, 15%);
       text-shadow: none;
     }
+  }
+
+  &--delete-modal {
+    display: inline;
+    width: auto;
   }
 
 // -------------------------------------


### PR DESCRIPTION
Seeing as the delete document button is placed right under the save session button I think it would be nice to ask the user before deleting documents.

This pull request adds user confirmation before deleting documents using the native JavaScript [confirm(...)](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) function.

Here is an example of a delete message:

> Are you sure you want to delete this document?
> 
> README.md
> Word count: 123

I wanted to use [Bootbox.js](http://bootboxjs.com/) confirm instead of the native JavaScript `confirm(...)` function.

The browser's native confirm message is not consistent with the rest of dillinger's UI and looks (and behaves) different between browsers without a lot of options for customization.

When I required `bootbox` I noticed that bootstrap's JavaScript is not being loaded.

I can understand if you think it's not worth adding a ton of JavaScript just for a fancy confirm dialog that is used by a fraction of the users.

~~However, if ever you don't mind adding bootstrap's JavaScript (through a CDN in production) then I would be glad to to use Bootbox confirm instead.~~

~~Tell me what you think about bootbox.~~

**Update:** I ended up using the existing modal (like in WTF is Dillinger? and GitHub import).  see [comment below](https://github.com/joemccann/dillinger/pull/520#issuecomment-215010668).