### PR TITLE
Adds drag and drop file import

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -66,6 +66,8 @@
 
   // File import.
   require('./file-import/drop-target.directive');
+  require('./file-import/choose-file.directive');
+  require('./file-import/import-file.controller');
 
   // Configure Dependencies
   angular.module('Dillinger', [

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -33,6 +33,7 @@
   // Documents
   require('./factorys/sheet.factory');
   require('./services/documents.service');
+  require('./components/file-drop-target.directive');
   require('./documents/documents-export.controller');
   require('./documents/documents.controller');
   require('./services/wordscount.service');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -33,7 +33,6 @@
   // Documents
   require('./factorys/sheet.factory');
   require('./services/documents.service');
-  require('./components/file-drop-target.directive');
   require('./documents/documents-export.controller');
   require('./documents/documents.controller');
   require('./services/wordscount.service');
@@ -65,6 +64,9 @@
   require('./zen-mode/zen-mode.controller');
   require('./zen-mode/zen-mode-toggle.directive');
 
+  // File import.
+  require('./file-import/drop-target.directive');
+
   // Configure Dependencies
   angular.module('Dillinger', [
     'diBase',
@@ -72,6 +74,7 @@
     'diNotify',
     'diUser',
     'diZenMode',
+    'diFileImport',
     'plugins.github',
     'plugins.dropbox',
     'plugins.googledrive',

--- a/public/js/base/base.controller.js
+++ b/public/js/base/base.controller.js
@@ -44,24 +44,29 @@ module.exports =
   var holder=document.body;
 //  alert(holder);
   holder.ondragover = function () { return false; };
-holder.ondragend = function () { return false; };
+  holder.ondragend = function () { return false; };
   holder.ondrop = function(event) {
     //alert(event.dataTransfer.files[0]);
     //console.log(event.dataTransfer.files);
-var file = event.dataTransfer.files[0];
+    var file = event.dataTransfer.files[0];
     var reader = new FileReader();
     reader.onload = function(event) {
-//alert(event.target.result);
-//alert(document.querySelector('#editor textarea').value);
-//alert(document.querySelector('#editor textarea').innerHTML);
-//document.querySelector('#editor textarea').innerHTML = event.target.result;
+    //alert(event.target.result);
+    //alert(document.querySelector('#editor textarea').value);
+    //alert(document.querySelector('#editor textarea').innerHTML);
+    //document.querySelector('#editor textarea').innerHTML = event.target.result;
 
-//$rootScope.editor.getSession()
-//$scope.$apply(function() {
+    //$rootScope.editor.getSession()
+    //$scope.$apply(function() {
 
-documentsService.setCurrentDocumentTitle(file.name);
-documentsService.setCurrentDocumentBody(event.target.result);
-updateDocument();
+    var item = documentsService.createItem();
+
+    documentsService.addItem(item);
+    documentsService.setCurrentDocument(item);
+
+    documentsService.setCurrentDocumentTitle(file.name);
+    documentsService.setCurrentDocumentBody(event.target.result);
+    $rootScope.$emit('document.refresh');
 //});
     };
      reader.readAsText(file);

--- a/public/js/base/base.controller.js
+++ b/public/js/base/base.controller.js
@@ -17,9 +17,7 @@ module.exports =
     'diBase.directives.previewToggle',
     'diBase.directives.preview'
   ])
-  .controller('Base', function($scope, $timeout, $rootScope, userService, documentsService) {
-
-  var updateDocument;
+  .controller('Base', function($scope, $rootScope, userService, documentsService) {
 
   $scope.profile             = userService.profile;
   $rootScope.currentDocument = documentsService.getCurrentDocument();
@@ -33,7 +31,7 @@ module.exports =
   $rootScope.editor.setOption('minLines', 50);
   $rootScope.editor.setOption('maxLines', 90000);
 
-  updateDocument = function() {
+  var updateDocument = function() {
     $rootScope.currentDocument = documentsService.getCurrentDocument();
     return $rootScope.editor.getSession().setValue($rootScope.currentDocument.body);
   };
@@ -41,5 +39,33 @@ module.exports =
   $scope.updateDocument = updateDocument;
 
   $rootScope.$on('document.refresh', updateDocument);
+
+
+  var holder=document.body;
+//  alert(holder);
+  holder.ondragover = function () { return false; };
+holder.ondragend = function () { return false; };
+  holder.ondrop = function(event) {
+    //alert(event.dataTransfer.files[0]);
+    //console.log(event.dataTransfer.files);
+var file = event.dataTransfer.files[0];
+    var reader = new FileReader();
+    reader.onload = function(event) {
+//alert(event.target.result);
+//alert(document.querySelector('#editor textarea').value);
+//alert(document.querySelector('#editor textarea').innerHTML);
+//document.querySelector('#editor textarea').innerHTML = event.target.result;
+
+//$rootScope.editor.getSession()
+//$scope.$apply(function() {
+
+documentsService.setCurrentDocumentTitle(file.name);
+documentsService.setCurrentDocumentBody(event.target.result);
+updateDocument();
+//});
+    };
+     reader.readAsText(file);
+    event.preventDefault();
+  };
 
 });

--- a/public/js/base/base.controller.js
+++ b/public/js/base/base.controller.js
@@ -15,8 +15,7 @@ module.exports =
     'diBase.directives.menuToggle',
     'diBase.directives.settingsToggle',
     'diBase.directives.previewToggle',
-    'diBase.directives.preview',
-    'diBase.directives.fileDropTarget'
+    'diBase.directives.preview'
   ])
   .controller('Base', function($scope, $rootScope, userService, documentsService) {
 

--- a/public/js/base/base.controller.js
+++ b/public/js/base/base.controller.js
@@ -15,7 +15,8 @@ module.exports =
     'diBase.directives.menuToggle',
     'diBase.directives.settingsToggle',
     'diBase.directives.previewToggle',
-    'diBase.directives.preview'
+    'diBase.directives.preview',
+    'diBase.directives.fileDropTarget'
   ])
   .controller('Base', function($scope, $rootScope, userService, documentsService) {
 
@@ -39,38 +40,4 @@ module.exports =
   $scope.updateDocument = updateDocument;
 
   $rootScope.$on('document.refresh', updateDocument);
-
-
-  var holder=document.body;
-//  alert(holder);
-  holder.ondragover = function () { return false; };
-  holder.ondragend = function () { return false; };
-  holder.ondrop = function(event) {
-    //alert(event.dataTransfer.files[0]);
-    //console.log(event.dataTransfer.files);
-    var file = event.dataTransfer.files[0];
-    var reader = new FileReader();
-    reader.onload = function(event) {
-    //alert(event.target.result);
-    //alert(document.querySelector('#editor textarea').value);
-    //alert(document.querySelector('#editor textarea').innerHTML);
-    //document.querySelector('#editor textarea').innerHTML = event.target.result;
-
-    //$rootScope.editor.getSession()
-    //$scope.$apply(function() {
-
-    var item = documentsService.createItem();
-
-    documentsService.addItem(item);
-    documentsService.setCurrentDocument(item);
-
-    documentsService.setCurrentDocumentTitle(file.name);
-    documentsService.setCurrentDocumentBody(event.target.result);
-    $rootScope.$emit('document.refresh');
-//});
-    };
-     reader.readAsText(file);
-    event.preventDefault();
-  };
-
 });

--- a/public/js/components/file-drop-target.directive.js
+++ b/public/js/components/file-drop-target.directive.js
@@ -1,0 +1,49 @@
+'use strict';
+
+module.exports =
+  angular
+  .module('diBase.directives.fileDropTarget', [])
+  .directive('fileDropTarget', function(documentsService) {
+
+  function createDropTarget(scope, el, attrs) {
+    el.on({
+      'dragover dragend': preventDefault,
+      'drop': function(event) {
+        preventDefault(event);
+
+        var file = event.originalEvent.dataTransfer.files[0];
+        readFile(file);
+      }
+    });
+
+    function readFile(file) {
+      var reader = new FileReader();
+      reader.onload = function(event) {
+        // Create a new document.
+        var item = documentsService.createItem();
+        documentsService.addItem(item);
+        documentsService.setCurrentDocument(item);
+
+        // Set the new documents title and body.
+        documentsService.setCurrentDocumentTitle(file.name);
+        documentsService.setCurrentDocumentBody(event.target.result);
+
+        // Refresh the editor and proview.
+        scope.$emit('document.refresh');
+      };
+
+      reader.readAsText(file);
+    }
+
+    function preventDefault(event) {
+      event.preventDefault();
+    }
+  }
+
+  var directive = {
+    restrict: 'A',
+    link: createDropTarget
+  };
+
+  return directive;
+});

--- a/public/js/file-import/choose-file.directive.js
+++ b/public/js/file-import/choose-file.directive.js
@@ -21,7 +21,7 @@ module.exports =
 
         el.change(function() {
           var file = this.files[0];
-          documentsService.importFile(file);
+          documentsService.importFile(file, true);
         });
       }
     };

--- a/public/js/file-import/choose-file.directive.js
+++ b/public/js/file-import/choose-file.directive.js
@@ -1,0 +1,46 @@
+module.exports =
+  angular
+  .module('diFileImport.directives.choose', [])
+  .directive('fileImportChooseFile', function($rootScope, documentsService) {
+    var $ = jQuery;
+
+    var directive = {
+      restrict: 'A',
+      link: function(scope, el, attrs) {
+        el.hide();
+
+        $rootScope.$on('importFile.choose', function() {
+          // Prevent angular bootstrap menu from tripping
+          // over itself in the click handler they bind to
+          // the document to close the menu.
+          var event = $.Event('click');
+          event.stopPropagation();
+
+          el.trigger(event);
+        });
+
+        el.change(function() {
+          var file = this.files[0];
+
+          var reader = new FileReader();
+          reader.onload = function(event) {
+            // Create a new document.
+            var item = documentsService.createItem();
+            documentsService.addItem(item);
+            documentsService.setCurrentDocument(item);
+
+            // Set the new documents title and body.
+            documentsService.setCurrentDocumentTitle(file.name);
+            documentsService.setCurrentDocumentBody(event.target.result);
+
+            // Refresh the editor and proview.
+            scope.$emit('document.refresh');
+          };
+
+          reader.readAsText(file);
+        });
+      }
+    };
+
+    return directive;
+  });

--- a/public/js/file-import/choose-file.directive.js
+++ b/public/js/file-import/choose-file.directive.js
@@ -21,23 +21,7 @@ module.exports =
 
         el.change(function() {
           var file = this.files[0];
-
-          var reader = new FileReader();
-          reader.onload = function(event) {
-            // Create a new document.
-            var item = documentsService.createItem();
-            documentsService.addItem(item);
-            documentsService.setCurrentDocument(item);
-
-            // Set the new documents title and body.
-            documentsService.setCurrentDocumentTitle(file.name);
-            documentsService.setCurrentDocumentBody(event.target.result);
-
-            // Refresh the editor and proview.
-            scope.$emit('document.refresh');
-          };
-
-          reader.readAsText(file);
+          documentsService.importFile(file);
         });
       }
     };

--- a/public/js/file-import/drop-target.directive.js
+++ b/public/js/file-import/drop-target.directive.js
@@ -2,7 +2,7 @@
 
 module.exports =
   angular
-  .module('diFileImport', [])
+  .module('diFileImport.directives.dnd', [])
   .directive('fileImportDropTarget', function(documentsService) {
 
   function createDropTarget(scope, el, attrs) {

--- a/public/js/file-import/drop-target.directive.js
+++ b/public/js/file-import/drop-target.directive.js
@@ -12,28 +12,9 @@ module.exports =
         preventDefault(event);
 
         var file = event.originalEvent.dataTransfer.files[0];
-        readFile(file);
+        documentsService.importFile(file);
       }
     });
-
-    function readFile(file) {
-      var reader = new FileReader();
-      reader.onload = function(event) {
-        // Create a new document.
-        var item = documentsService.createItem();
-        documentsService.addItem(item);
-        documentsService.setCurrentDocument(item);
-
-        // Set the new documents title and body.
-        documentsService.setCurrentDocumentTitle(file.name);
-        documentsService.setCurrentDocumentBody(event.target.result);
-
-        // Refresh the editor and proview.
-        scope.$emit('document.refresh');
-      };
-
-      reader.readAsText(file);
-    }
 
     function preventDefault(event) {
       event.preventDefault();

--- a/public/js/file-import/drop-target.directive.js
+++ b/public/js/file-import/drop-target.directive.js
@@ -2,8 +2,8 @@
 
 module.exports =
   angular
-  .module('diBase.directives.fileDropTarget', [])
-  .directive('fileDropTarget', function(documentsService) {
+  .module('diFileImport', [])
+  .directive('fileImportDropTarget', function(documentsService) {
 
   function createDropTarget(scope, el, attrs) {
     el.on({

--- a/public/js/file-import/drop-target.directive.js
+++ b/public/js/file-import/drop-target.directive.js
@@ -7,7 +7,12 @@ module.exports =
 
   function createDropTarget(scope, el, attrs) {
     el.on({
-      'dragover dragend': preventDefault,
+      'dragover': function(e) {
+        // Gives the user visual feedback by changing the
+        // cursor to copy (usually a triangle with a plus sign).
+        e.originalEvent.dataTransfer.dropEffect = 'copy';
+        preventDefault(e);
+      },
       'drop': function(event) {
         preventDefault(event);
 

--- a/public/js/file-import/import-file.controller.js
+++ b/public/js/file-import/import-file.controller.js
@@ -1,0 +1,13 @@
+module.exports =
+  angular
+  .module('diFileImport', [
+    'diFileImport.directives.choose',
+    'diFileImport.directives.dnd'
+  ])
+  .controller('ImportFile', function($scope, $rootScope) {
+    $scope.choose = function() {
+      $rootScope.$emit('importFile.choose');
+    };
+
+    alert($scope.choose);
+  });

--- a/public/js/file-import/import-file.controller.js
+++ b/public/js/file-import/import-file.controller.js
@@ -8,6 +8,4 @@ module.exports =
     $scope.choose = function() {
       $rootScope.$emit('importFile.choose');
     };
-
-    alert($scope.choose);
   });

--- a/public/js/services/documents.service.js
+++ b/public/js/services/documents.service.js
@@ -23,6 +23,7 @@ module.exports =
     size:                    size,
     getItems:                getItems,
     removeItems:             removeItems,
+    importFile:              importFile,
     setCurrentDocument:      setCurrentDocument,
     getCurrentDocument:      getCurrentDocument,
     setCurrentDocumentTitle: setCurrentDocumentTitle,
@@ -180,6 +181,32 @@ module.exports =
   function getCurrentDocumentBody() {
     service.setCurrentDocumentBody($rootScope.editor.getSession().getValue());
     return service.currentDocument.body;
+  }
+
+  /**
+   *    Create a document from a file on disc.
+   *
+   *    @param  {File}  file  The file to import
+   *            (see: https://developer.mozilla.org/en/docs/Web/API/File).
+   */
+  function importFile(file) {
+    var reader = new FileReader();
+
+    reader.onload = function(event) {
+      // Create a new document.
+      var item = createItem();
+      addItem(item);
+      setCurrentDocument(item);
+
+      // Set the new documents title and body.
+      setCurrentDocumentTitle(file.name);
+      setCurrentDocumentBody(event.target.result);
+
+      // Refresh the editor and proview.
+      $rootScope.$emit('document.refresh');
+    };
+
+    reader.readAsText(file);
   }
 
 /**

--- a/views/dropdowns/import_from.ejs
+++ b/views/dropdowns/import_from.ejs
@@ -49,3 +49,9 @@
     </a>
   </li>
   <% } %>
+
+  <li ng-controller="ImportFile as importFile">
+    <a class="linked" ng-click="choose()">
+      <span>File on disc</span>
+    </a>
+  </li>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -48,6 +48,8 @@
 </head>
 <body ng-controller="Base" file-import-drop-target>
 
+  <input type="file" accept=".md,.markdown" file-import-choose-file />
+
   <form method="POST" id="downloader">
     <input type="hidden" name="name">
     <input type="hidden" name="unmd">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -46,7 +46,7 @@
 
 
 </head>
-<body ng-controller="Base" file-drop-target>
+<body ng-controller="Base" file-import-drop-target>
 
   <form method="POST" id="downloader">
     <input type="hidden" name="name">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -46,7 +46,7 @@
 
 
 </head>
-<body ng-controller="Base">
+<body ng-controller="Base" file-drop-target>
 
   <form method="POST" id="downloader">
     <input type="hidden" name="name">


### PR DESCRIPTION
This pull request allows the user to import files by dragging and dropping them into Dillinger.

It also allows the user to use the browser's file chooser by clicking Import from -> File on disc.
<img width="900" alt="screen shot 2016-04-30 at 9 02 26 pm" src="https://cloud.githubusercontent.com/assets/5201428/14937649/e859892c-0f16-11e6-97df-5b72383e5288.png">

When the user uses the Import from -> File on disc menu they get a tip notification telling them:

> You can also drag and drop files into dillinger.

When the user drags a file into the Dillinger page it will change to `cursor: copy;` which gives the user an indication that dropping the file will copy (import) the file.
<img width="1332" alt="screen shot 2016-04-30 at 9 05 19 pm" src="https://cloud.githubusercontent.com/assets/5201428/14937680/e827ed8a-0f17-11e6-9163-9e1bd3df4579.png">

I prevent the user from importing binary files with the following notification:

> Importing binary files will cause dillinger to become unresponsive.

Fell free to improve these notification messages.

## Known limitations

### No IE 9 Support
I use the [FileReader](https://developer.mozilla.org/en/docs/Web/API/FileReader) Object to read the file without sending it back and forth to the server for no reason.

If we have IE 9 uses I doubt they will want to drag and drop files.

I have enough Internet Explorer nonsense at work, so I'm not going to deal with this even if someone opens an issue about this.

### No way to specify an encoding
It assumes the input is `UTF-8`.
I will implement support for this if someone opens an issue about this.

### No way to handle very large files
I tried dragging a 17GB MKV file to see what happens.
It seems that loading just silently fails.
Once again I'm not going into this unless someone opens an issue about this.