### PR TITLE
Adds the Node.js v4+ requirement to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ And of course Dillinger itself is open source with a [public repository][dill]
 
 ### Installation
 
+Dillinger requires [Node.js](https://nodejs.org/) v4+ to run.
+
 You need Gulp installed globally:
 
 ```sh
@@ -97,7 +99,7 @@ $ karma start
 ### Docker
 Dillinger is very easy to install and deploy in a Docker container.
 
-By default, the Docker will expose port 80, so change this within the Dockerfile if necessary. When ready, simply use the Dockerfile to build the image. 
+By default, the Docker will expose port 80, so change this within the Dockerfile if necessary. When ready, simply use the Dockerfile to build the image.
 
 ```sh
 cd dillinger
@@ -157,4 +159,3 @@ MIT
    [PlGh]:  <https://github.com/joemccann/dillinger/tree/master/plugins/github/README.md>
    [PlGd]: <https://github.com/joemccann/dillinger/tree/master/plugins/googledrive/README.md>
    [PlOd]: <https://github.com/joemccann/dillinger/tree/master/plugins/onedrive/README.md>
-


### PR DESCRIPTION
I'm not sure how you want our commit, code review, merge and deploy workflows to look like, so I'm just going to make changes in my fork and open pull requests unit it's more clear to me.

As mentioned in #523 Dillinger requires Node.js v4+ (for [Arrow functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions) support) to run.

This pull request adds this requirement to README.md.