### PR TITLE
Moves GitHub save base64 encoding to the server. fixes #481

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ And of course Dillinger itself is open source with a [public repository][dill]
 
 ### Installation
 
+Dillinger requires [Node.js](https://nodejs.org/) v4+ to run.
+
 You need Gulp installed globally:
 
 ```sh
@@ -97,7 +99,7 @@ $ karma start
 ### Docker
 Dillinger is very easy to install and deploy in a Docker container.
 
-By default, the Docker will expose port 80, so change this within the Dockerfile if necessary. When ready, simply use the Dockerfile to build the image. 
+By default, the Docker will expose port 80, so change this within the Dockerfile if necessary. When ready, simply use the Dockerfile to build the image.
 
 ```sh
 cd dillinger
@@ -157,4 +159,3 @@ MIT
    [PlGh]:  <https://github.com/joemccann/dillinger/tree/master/plugins/github/README.md>
    [PlGd]: <https://github.com/joemccann/dillinger/tree/master/plugins/googledrive/README.md>
    [PlOd]: <https://github.com/joemccann/dillinger/tree/master/plugins/onedrive/README.md>
-

--- a/app.js
+++ b/app.js
@@ -28,7 +28,8 @@ var config = require('./config')()
   , env = process.env.NODE_ENV || 'development';
 
 app.set('port', process.env.PORT || 8080)
-app.set('bind-address', process.env.BIND_ADDRESS)
+app.set('bind-address', process.env.BIND_ADDRESS || 'localhost')
+
 app.set('views', __dirname + '/views')
 app.set('view engine', 'ejs')
 

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -8,7 +8,7 @@ var
 gulp.task('browserSync', function() {
   browserSync({
     files: ['views/**'],
-    proxy: app.get('bind-address') +'8090',
+    proxy: 'localhost:8090',
     notify: false
   });
 });

--- a/gulp/tasks/uncss.js
+++ b/gulp/tasks/uncss.js
@@ -12,7 +12,7 @@ gulp.task("uncss", function() {
 
   return gulp.src("public/css/app.css")
     .pipe(uncss({
-      html: ["http://' + app.get('bind-address') + ':8080"],
+      html: ["http://localhost:8080"],
       ignore: [/zen/, /document/, /modal/, /settings/, /button/, /btn/, /toggle/, /menu/, /sidebar/, /dropdown/, /ace/, /editor/, /sr/, /form/, /di/, /not/]
     }))
     .on("error", handleErrors)

--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -26,16 +26,16 @@ gulp.task('webpack:dev', function(cb) {
   return new webpackDevServer(devCompiler, {
     proxy: {
       '*': {
-        target: 'http://' + app.get('bind-address') + ':8080',
+        target: 'http://localhost:8080',
         secure: false,
       },
     },
-    publicPath:  'http://' + app.get('bind-address') + ':8090/js/',
+    publicPath:  'http://localhost:8090/js/',
     hot:         false,
     stats: {
       colors: true
     }
-  }).listen(8090, app.get('bind-address'), function(err) {
+  }).listen(8090, 'localhost', function(err) {
 
     if (err) {
       throw new gutil.PluginError('webpack:dev', err);

--- a/plugins/github/github.js
+++ b/plugins/github/github.js
@@ -349,7 +349,7 @@ exports.Github = (function() {
           message: message // Better commit messages?
         , path: path
         , branch: branch
-        , content: data.data
+        , content: new Buffer(data.data).toString('base64')
         , sha: sha
       };
 

--- a/public/js/plugins/github/github.service.js
+++ b/public/js/plugins/github/github.service.js
@@ -193,7 +193,7 @@ module.exports =
       di = diNotify('Saving Document on Github...');
       return $http.post('save/github', {
         uri:     data.uri,
-        data:    btoa(data.body),
+        data:    data.body,
         path:    data.path,
         sha:     data.sha,
         branch:  data.branch,

--- a/public/scss/vendor/bootstrap-sass-3.2.0/test/test_helper.rb
+++ b/public/scss/vendor/bootstrap-sass-3.2.0/test/test_helper.rb
@@ -25,7 +25,7 @@ Capybara.register_driver :poltergeist do |app|
 end
 
 Capybara.configure do |config|
-  config.app_host = 'http://' + app.get('bind-address') + ':7000'
+  config.app_host = 'http://localhost:7000'
   config.default_driver    = :poltergeist
   config.javascript_driver = :poltergeist
   config.server_port       = 7000


### PR DESCRIPTION
This pull request replaces the client side base64 encoding which was done using the [WindowBase64.btoa()](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa) method with, server side encoding using the built in [Buffer](https://nodejs.org/api/buffer.html) class.

    new Buffer('...').toString('base64')

@joemccann Seeing as we have no test suite setup in the server I wanted to discuss this (and other architecture stuff) with you first.

I manually made sure that putting the same input into the `btoa()` method and `new Buffer('...').toString('base64')` produces the same output.

I also manually made sure that non latin characters are sent properly in UTF-8.