### PR TITLE
Removes gulp build --prod from Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ $ npm i -g gulp
 $ git clone [git-repo-url] dillinger
 $ cd dillinger
 $ npm i -d
-$ gulp build --prod
 $ NODE_ENV=production node app
 ```
 


### PR DESCRIPTION
After adding gulp build --prod as a postinstall script running `gulp build --prod` is no longer necessary.

This PR removes it from the installation section of the Readme.

I guess I forgot to add this in #530, but at least we can use this as an example of how Travis CI works with pull request.