### PR TITLE
Makes code highlighting more consistent with GitHub 

### DIFF
--- a/plugins/core/markdown-it.js
+++ b/plugins/core/markdown-it.js
@@ -10,7 +10,7 @@ var hljs = require('highlight.js')
         if (lang && hljs.getLanguage(lang)) {
           return hljs.highlight(lang, str).value;
         } else {
-          return hljs.highlightAuto(str).value;
+          return str.value;
         }
       }
     });
@@ -46,4 +46,4 @@ md
   .use(require('markdown-it-abbr'))
   .use(require('markdown-it-checkbox'));
 
-exports.md = md 
+exports.md = md


### PR DESCRIPTION
This PR makes code highlighting more consistent with GitHub by only highlighting code if a language is specified.

This fixes #203 and fixes #218