### PR TITLE
Makes markdown-it apply bootstrap table CSS

### DIFF
--- a/plugins/core/markdown-it.js
+++ b/plugins/core/markdown-it.js
@@ -46,4 +46,11 @@ md
   .use(require('markdown-it-abbr'))
   .use(require('markdown-it-checkbox'));
 
+md.renderer.rules.table_open = function(tokens, idx, options, env, self) {
+  var token = tokens[idx];
+  token.attrPush([ 'class', 'table table-striped table-bordered' ]);
+
+  return self.renderToken(tokens, idx, options);
+};
+
 exports.md = md

--- a/public/scss/app.scss
+++ b/public/scss/app.scss
@@ -57,6 +57,7 @@
 @import 'components/pagination';
 @import 'components/diNotify';
 @import 'components/zen-mode';
+@import 'components/table';
 // @import 'components/bucket';
 // @import 'components/card';
 // @import 'components/cell';

--- a/public/scss/components/_table.scss
+++ b/public/scss/components/_table.scss
@@ -1,0 +1,3 @@
+#preview .table {
+  width: auto;
+}

--- a/public/scss/vendor/bootstrap-sass-3.2.0/assets/stylesheets/bootstrap.scss
+++ b/public/scss/vendor/bootstrap-sass-3.2.0/assets/stylesheets/bootstrap.scss
@@ -12,7 +12,7 @@
 // @import "bootstrap/type";
 @import "bootstrap/code";
 /* @import "bootstrap/grid"; */
-/* @import "bootstrap/tables"; */
+@import "bootstrap/tables";
 @import "bootstrap/forms";
 @import "bootstrap/buttons";
 


### PR DESCRIPTION
This pull request makes markdown-it apply bootstrap styles to GFM tables.

![screen shot 2016-05-10 at 8 04 12 pm](https://cloud.githubusercontent.com/assets/5201428/15155645/1737c722-16ec-11e6-8120-f63c827170d3.png)

This fixes #219 