### PR TITLE
Adds the "preview as" menu to the navbar

### DIFF
--- a/plugins/core/server.js
+++ b/plugins/core/server.js
@@ -48,7 +48,14 @@ var express = require('express')
     if (req.body.preview === 'false') {
       res.attachment( name );
     } else {
-      res.type('txt');
+      // We don't use text/markdown because my "favorite" browser
+      // (IE) ignores the Content-Disposition: inline; and prompts
+      // the user to download the file.
+      res.type('text');
+
+      // For some reason IE and Chrome ignore the filename
+      // field when Content-Type: text/plain;
+      res.set('Content-Disposition', `inline; filename="${name}"`);
     }
 
     res.end( unmd );
@@ -75,6 +82,7 @@ var express = require('express')
       res.attachment( name );
     } else {
       res.type('html');
+      res.set('Content-Disposition', `inline; filename="${name}"`);
     }
 
     res.end( html );
@@ -121,6 +129,7 @@ var express = require('express')
           res.attachment( name )
         } else {
           res.type('pdf')
+          res.set('Content-Disposition', `inline; filename="${name}"`)
         }
 
         res.sendFile( filename, {}, function() {

--- a/plugins/core/server.js
+++ b/plugins/core/server.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var express = require('express')
   , app = module.exports = express()
   , fs = require('fs')
@@ -43,8 +45,13 @@ var express = require('express')
       name = name + '.md'
     }
 
-   res.attachment( name );
-   res.end( unmd );
+    if (req.body.preview === 'false') {
+      res.attachment( name );
+    } else {
+      res.type('txt');
+    }
+
+    res.end( unmd );
   }
 
   var fetchHtml = function(req, res) {
@@ -64,7 +71,12 @@ var express = require('express')
 
     var filename = path.resolve(__dirname, '../../downloads/files/html/' + name )
 
-    res.attachment( name );
+    if (req.body.preview === 'false') {
+      res.attachment( name );
+    } else {
+      res.type('html');
+    }
+
     res.end( html );
   }
 
@@ -105,7 +117,12 @@ var express = require('express')
       page.property('viewportSize', { width: 1024, height: 768 })
 
       page.render(filename).then(function() {
-        res.attachment( name )
+        if (req.body.preview === 'false') {
+          res.attachment( name )
+        } else {
+          res.type('pdf')
+        }
+
         res.sendFile( filename, {}, function() {
           // Cleanup.
           fs.unlink(filename)

--- a/public/js/documents/documents-export.controller.js
+++ b/public/js/documents/documents-export.controller.js
@@ -6,14 +6,15 @@ module.exports =
   .module('diDocuments.export', [
     'diDocuments.service'
   ])
-  .controller('DocumentsExport', function($scope, documentsService) {
+  .controller('DocumentsExport', function($scope, $attrs, documentsService) {
 
   var vm = this,
       $ = jQuery,
-      $downloader = $(document.getElementById('downloader')),
+      $downloader = $('#downloader'),
       $name = $downloader.find('[name=name]'),
       $unmd = $downloader.find('[name=unmd]'),
-      $formatting = $downloader.find('[name=formatting]');
+      $formatting = $downloader.find('[name=formatting]'),
+      $preview = $downloader.find('[name=preview]');
 
 
   vm.asHTML       = asHTML;
@@ -23,6 +24,9 @@ module.exports =
 
   function initDownload(action, styled) {
     $downloader[0].action = action;
+    $downloader[0].target = $attrs.diTarget;
+
+    $preview.val( $attrs.diTarget === 'preview' );
     $name.val( documentsService.getCurrentDocumentTitle() );
     $unmd.val( documentsService.getCurrentDocumentBody() );
     $formatting.val( styled );

--- a/views/dropdowns/export_as.ejs
+++ b/views/dropdowns/export_as.ejs
@@ -1,4 +1,4 @@
-<ul class="dropdown dropdown-menu" role="menu" ng-controller="DocumentsExport as export">
+<ul class="dropdown dropdown-menu" role="menu" ng-controller="DocumentsExport as export" di-target="<%= exportTarget %>">
   <li>
     <a ng-click="export.asHTML()" class="export-html">HTML</a>
   </li>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -54,6 +54,7 @@
     <input type="hidden" name="name">
     <input type="hidden" name="unmd">
     <input type="hidden" name="formatting">
+    <input type="hidden" name="preview">
   </form>
 
   <%- include splashscreen %>

--- a/views/navbar.ejs
+++ b/views/navbar.ejs
@@ -9,7 +9,13 @@
   <nav class="nav nav-right">
     <ul class="menu menu-utilities">
       <li class="menu-item menu-item--export-as has-dropdown" dropdown>
+        <a class="dropdown-toggle" dropdown-toggle>Preview as <span class="caret"></span></a>
+        <% var exportTarget = 'preview'; %>
+        <%- include dropdowns/export_as %>
+      </li>
+      <li class="menu-item menu-item--export-as has-dropdown" dropdown>
         <a class="dropdown-toggle" dropdown-toggle>Export as <span class="caret"></span></a>
+        <% var exportTarget = '_top'; %>
         <%- include dropdowns/export_as %>
       </li>
       <li class="menu-item menu-item--save-to has-dropdown" dropdown>


### PR DESCRIPTION
As requested in #540, this pull request adds the "preview as" menu to the navbar.

The new menu allows the user to preview the exported document in a new browser window/tab.

### Known issue
The new export window is (intentionally) opened to the `preview` target.

This means that if the user leaves the tab/window open the preview will be reloaded in the existing tab but the window will not gain focus.

There is two ways (that I don't like) to work around this.

1. Open the window to the `_blank` target which will produce a lot of unclosed preview tabs.
2. Close (and reopen) the existing tab next time the user tries to preview, which unless I look at the `previewWindow.location` the user might navigate to a different page in that tab and I will close the tab without confirmation (or history to go back).

If someone will complain about this issue I will give option 2 a shot.