### PR TITLE
Add the packaging metadata to build the dillinger snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,8 +10,9 @@ confinement: strict
 
 apps:
   server:
-    command: node $SNAP/lib/node_modules/dillinger/app.js
+    command: node $SNAP/lib/node_modules/Dillinger/app.js
     plugs: [network-bind]
+    daemon: simple
 
 parts:
   dillinger:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: dillinger
+version: master
+summary: The last Markdown editor, ever
+description: |
+  Dillinger is a cloud-enabled, mobile-ready, offline-storage, AngularJS powered
+  HTML5 Markdown editor.
+
+grade: devel
+confinement: strict
+
+apps:
+  server:
+    command: node $SNAP/lib/node_modules/dillinger/app.js
+    plugs: [network-bind]
+
+parts:
+  dillinger:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.