### PR TITLE
Add the is-property module as a dependency of ths snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,3 +19,4 @@ parts:
     plugin: nodejs
     node-engine: '4.4.7'
     build-packages: [bzip2, git]
+    node-packages: [is-property]


### PR DESCRIPTION
is-property seems to be a transitive dependency, which is not found when building the snap. It is inside a node_modules dir, so that's weird.

I've searched information about this and found one possible cause. They said that the dependency was too many levels deep, so it's path was too long. However, the report was on windows, and it sounds like something windows would do, but it doesn't sound like linux would fail that way. This PR fixes the build by making it a direct dependency, which puts it many levels higher ¯\_(ツ)_/¯

This error wasn't found on travis because the errors during the snap build are not marking the run as failed. If you would like future snapcraft errors to be blockers I can propose that change. I would be available to help if something goes wrong, and I can put dillinger in our nightly suite to make sure that we never break you; so any errors would come from changes in the PR. But it's up to you. 