### PR TITLE
Dockerfile: remove redundant layering, clean npm cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # deps.json only has the dependencies from the package.json.
 # this is faster via npm run build-docker
 COPY package.json ./package.json
-RUN npm install
+RUN npm install \
+    && npm cache clean
 
 # Copy source over and create configs dir
 COPY . .
 RUN mkdir -p /configs
-
-# Trim the fat
-RUN apt-get purge -y ${BUILD_DEPS} \
-    && apt-get autoremove -y 
 
 EXPOSE 8080
 ENV NODE_ENV=production


### PR DESCRIPTION
The `apt-get purge/autoremove` step is redundant, one cannot reduce an image's final size retroactively. Effectively, this PR reduces final virtual size from `645MB` to `612MB`.