### PR TITLE
readme update for IMHO correct port, and update deprecated maintainer…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nodesource/nsolid:boron-2.1.0
 
-MAINTAINER Joe McCann <joe@nodesource.com>
+LABEL maintainer "Joe McCann <joe@nodesource.com>"
 
 # Install our dependencies (libfontconfig for phantomjs)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $ gulp build dist --prod
 ### Docker
 Dillinger is very easy to install and deploy in a Docker container.
 
-By default, the Docker will expose port 80, so change this within the Dockerfile if necessary. When ready, simply use the Dockerfile to build the image.
+By default, the Docker will expose port 8080, so change this within the Dockerfile if necessary. When ready, simply use the Dockerfile to build the image.
 
 ```sh
 cd dillinger
@@ -125,7 +125,7 @@ docker build -t joemccann/dillinger:${package.json.version}
 ```
 This will create the dillinger image and pull in the necessary dependencies. Be sure to swap out `${package.json.version}` with the actual version of Dillinger.
 
-Once done, run the Docker image and map the port to whatever you wish on your host. In this example, we simply map port 8000 of the host to port 80 of the Docker (or whatever port was exposed in the Dockerfile):
+Once done, run the Docker image and map the port to whatever you wish on your host. In this example, we simply map port 8000 of the host to port 8080 of the Docker (or whatever port was exposed in the Dockerfile):
 
 ```sh
 docker run -d -p 8000:8080 --restart="always" <youruser>/dillinger:${package.json.version}


### PR DESCRIPTION
ports should all point to 8080 i guess.
maintainer is now deprecated and we should use label instead.

if i did oversee something, just change it ;)