### PR TITLE
use the latest node lts version to build the snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,6 +17,5 @@ parts:
   dillinger:
     source: .
     plugin: nodejs
-    node-engine: '4.4.7'
     build-packages: [bzip2, git]
     node-packages: [is-property]


### PR DESCRIPTION
A recent version of snapcraft uses the latest released LTS node version if none is specified.
The latest LTS is newer than 4.4.7, so the resulting package is better.