### PR TITLE
Add link to the Markdown Guide

### DIFF
--- a/views/dropdowns/settings.ejs
+++ b/views/dropdowns/settings.ejs
@@ -34,8 +34,8 @@
   </li>
   -->
   <li>
-    <a target="_blank" href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet">
-      <span>Cheat Sheet</span>
+    <a target="_blank" href="https://www.markdownguide.org">
+      <span>Markdown Help</span>
     </a>
   </li>
   <li>


### PR DESCRIPTION
Hey @joemccann! I'd like to suggest replacing the current [Cheat Sheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) link in the Dillinger settings bar with a "Markdown Help" link to the [Markdown Guide](https://www.markdownguide.com). 

There are a couple reasons why I think this is a good idea:

- The Markdown Guide is an active, [open source project](https://github.com/mattcone/markdown-guide).
- Unlike the Markdown Cheatsheet, the Markdown Guide is designed to be complete reference to Markdown. We've documented edge-cases and provided a getting started guide for complete beginners. 
- The Markdown Guide uses Dillinger as an example. 😄 

Thanks for considering this!

Disclosure: I created the Markdown Guide. 