### PR TITLE
Disable Third (Unnecessary) Scrollbar

### DIFF
--- a/public/scss/foundation/_base.scss
+++ b/public/scss/foundation/_base.scss
@@ -19,6 +19,7 @@ body {
   font-weight: map-get($bodytype, regular);
   line-height: 2rem;
   height: 100%;
+  overflow: hidden;
 }
 
 // -------------------------------------


### PR DESCRIPTION
Since the editor and preview windows provide a dedicated scrollbar, the third scrollbar is unnecessary. This change prevents said scrollbar from appearing.