### PR TITLE
zen mode breaks preview fix

### DIFF
--- a/views/editor-headers.ejs
+++ b/views/editor-headers.ejs
@@ -1,6 +1,6 @@
 <div class="editor-header editor-header--first">
   <h3 class="title">Markdown</h3>
-  <toggle-zen-mode></toggle-zen-mode>
+  <toggle-zen-mode ng-if="!$root.viewSrcMode"></toggle-zen-mode>
 </div>
 <div class="editor-header">
   <h3 class="title">Preview</h3>


### PR DESCRIPTION
Zen mode breaks the formatting of the document when toggled whilst in preview mode.

Fix was to hide the zen mode toggle while in preview mode

Before
---

<img width="1438" alt="screen shot 2018-09-23 at 11 45 43" src="https://user-images.githubusercontent.com/1556430/45927139-6214e880-bf26-11e8-8793-66667bcbdc9e.png">


After
---

<img width="1438" alt="screen shot 2018-09-23 at 11 44 18" src="https://user-images.githubusercontent.com/1556430/45927124-2c6fff80-bf26-11e8-8b5a-70c547ae6abc.png">


fixes #678 