### PR TITLE
Make toggle for 80 char print margin

### DIFF
--- a/public/js/services/user.service.js
+++ b/public/js/services/user.service.js
@@ -10,6 +10,7 @@ module.exports =
       enableAutoSave:        true,
       enableWordsCount:      true,
       enableCharactersCount: true,
+      enablePrintMargin:     false,
       enableScrollSync:      false,
       enableNightMode:       false,
       enableGitHubComment:   true

--- a/public/js/user/user.controller.js
+++ b/public/js/user/user.controller.js
@@ -46,11 +46,13 @@ module.exports =
   vm.toggleAutoSave        = toggleAutoSave;
   vm.toggleWordsCount      = toggleWordsCount;
   vm.toggleCharactersCount = toggleCharactersCount;
+  vm.togglePrintMargin     = togglePrintMargin;
   vm.toggleNightMode       = toggleNightMode;
   vm.toggleScrollSync      = toggleScrollSync;
   vm.resetProfile          = resetProfile;
   vm.showAbout             = showAbout;
 
+  setPrintMargin();
   doSync();
 
   // ------------------------------
@@ -82,6 +84,15 @@ module.exports =
   function toggleCharactersCount(e) {
     e.preventDefault();
     vm.profile.enableCharactersCount = !vm.profile.enableCharactersCount;
+    userService.save(vm.profile);
+
+    return false;
+  }
+
+  function togglePrintMargin(e) {
+    e.preventDefault();
+    vm.profile.enablePrintMargin = !vm.profile.enablePrintMargin;
+    setPrintMargin();
     userService.save(vm.profile);
 
     return false;
@@ -126,6 +137,10 @@ module.exports =
     return $timeout(function() {
       return $rootScope.$apply();
     }, 0);
+  }
+
+  function setPrintMargin() {
+    $rootScope.editor.setShowPrintMargin(vm.profile.enablePrintMargin);
   }
 
   function doSync() {

--- a/views/dropdowns/settings.ejs
+++ b/views/dropdowns/settings.ejs
@@ -18,6 +18,12 @@
     </a>
   </li>
   <li>
+    <a ng-click="user.togglePrintMargin($event)">
+      <span class="has-checkbox">Print Margin</span>
+      <switch class="toggle-print-margin" value="user.profile.enablePrintMargin"></switch>
+    </a>
+  </li>
+  <li>
     <a ng-click="user.toggleScrollSync($event)">
       <span class="has-checkbox">Scroll Sync</span>
       <switch class="toggle-scroll-sync" value="user.profile.enableScrollSync"></switch>


### PR DESCRIPTION
PR for #656 

1. Make a variable in the profile "enablePrintMargin" that stores if this feature is enabled/disabled
2. Add a menu item in the settings menu for "Print Margin"
3. Create a function in the controller to `setPrintMargin()` based on the `enablePrintMargin` variable
4. Call this function on startup
5. Also call this function when the toggle is hit, store the opposite value in the profile and call the function to set

Some notes:
* I don't know if 2. "Print Margin" is descriptive enough as a setting. Maybe it should be renamed?
* I don't know if there's a better way to call [this line](https://github.com/joemccann/dillinger/blob/master/public/js/base/base.controller.js#L28) than the function I implemented in item 4.
* When the settings menu is active, it's hard to tell that it is actually activated because the `overlay` is approximately the same color as the `ace_print-margin`

New menu item:
![image](https://user-images.githubusercontent.com/1299430/46679979-0f8a2c00-cbb6-11e8-9f21-14ac5040bb7b.png)
Setting on:
![image](https://user-images.githubusercontent.com/1299430/46679994-19139400-cbb6-11e8-8fd8-b683d44c1ec7.png)
Menu hidden:
![image](https://user-images.githubusercontent.com/1299430/46680015-2466bf80-cbb6-11e8-8a45-9b56ebe81098.png)
