### PR TITLE
Set the current document title to the first title in pasted text

### DIFF
--- a/public/js/user/user.controller.js
+++ b/public/js/user/user.controller.js
@@ -8,7 +8,7 @@ module.exports =
     'diDocuments.service.wordcount',
     'diDocuments.service.charactercount'
   ])
-  .controller('User', function($rootScope, $timeout, $modal, userService, wordsCountService, charactersCountService) {
+  .controller('User', function($rootScope, $timeout, $modal, userService, documentsService, wordsCountService, charactersCountService) {
 
   var vm = this;
 
@@ -40,6 +40,7 @@ module.exports =
 
   $rootScope.$on('preview.updated', updateWords);
   $rootScope.$on('preview.updated', updateCharacters);
+  $rootScope.editor.on('paste', pasteDetected);
 
   // Methods on the Controller
   vm.toggleGitHubComment   = toggleGitHubComment;
@@ -126,6 +127,28 @@ module.exports =
     return $timeout(function() {
       return $rootScope.$apply();
     }, 0);
+  }
+
+  function pasteDetected() {
+    // only change if the title if still set to the default
+    if (documentsService.getCurrentDocumentTitle() == 'Untitled Document.md') {
+      // wait for preview to process Markdown, but only run once then destroy
+      var destroyListener = $rootScope.$on('preview.updated', function() {
+        setDocumentTitleToFirstHeader();
+
+        destroyListener();
+      });
+    }
+  }
+
+  function setDocumentTitleToFirstHeader() {
+    // set the document's name to the first header if there is one
+    try {
+      documentsService.setCurrentDocumentTitle(angular.element(document).find('#preview').find('h1')[0].textContent);
+    }
+    // don't do anything if there's no header
+    catch(err) {}
+    return;
   }
 
   function doSync() {


### PR DESCRIPTION
PR for #645 

1. Register a listener to Ace's paste event
2. Check that the document is still untitled
3. If so, register a one-time listener on `preview.updated` to detect when the Markdown is parsed
4. Find the first header in the Markdown (if there is one) and set the Document's title to it

I had to pull in the documentsService to the user controller to read and write the document's title

I also tried to make it work while typing but it wasn't easy to detect when a header line is complete and should be selected as the title. If this is a desired feature, do you have any ideas on how to complete it?