### PR TITLE
Change tab size in settings menu

### DIFF
--- a/public/js/services/user.service.js
+++ b/public/js/services/user.service.js
@@ -11,6 +11,7 @@ module.exports =
       enableWordsCount:      true,
       enableCharactersCount: true,
       enableScrollSync:      false,
+      tabSize:               4,
       enableNightMode:       false,
       enableGitHubComment:   true
     },

--- a/public/js/user/user.controller.js
+++ b/public/js/user/user.controller.js
@@ -8,7 +8,7 @@ module.exports =
     'diDocuments.service.wordcount',
     'diDocuments.service.charactercount'
   ])
-  .controller('User', function($rootScope, $timeout, $modal, userService, wordsCountService, charactersCountService) {
+  .controller('User', function($rootScope, $scope, $timeout, $modal, userService, wordsCountService, charactersCountService) {
 
   var vm = this;
 
@@ -46,11 +46,13 @@ module.exports =
   vm.toggleAutoSave        = toggleAutoSave;
   vm.toggleWordsCount      = toggleWordsCount;
   vm.toggleCharactersCount = toggleCharactersCount;
+  vm.storeTabSize          = storeTabSize;
   vm.toggleNightMode       = toggleNightMode;
   vm.toggleScrollSync      = toggleScrollSync;
   vm.resetProfile          = resetProfile;
   vm.showAbout             = showAbout;
 
+  setTabSize();
   doSync();
 
   // ------------------------------
@@ -96,6 +98,14 @@ module.exports =
     return false;
   }
 
+  function storeTabSize() {
+    vm.profile.tabSize = $scope.tabsize;
+    userService.save(vm.profile);
+    setTabSize();
+
+    return false;
+  }
+
   function toggleNightMode(e) {
     e.preventDefault();
     vm.profile.enableNightMode = !vm.profile.enableNightMode;
@@ -126,6 +136,13 @@ module.exports =
     return $timeout(function() {
       return $rootScope.$apply();
     }, 0);
+  }
+
+  function setTabSize() {
+    $scope.tabsize = vm.profile.tabSize;
+    $rootScope.editor.session.setTabSize($scope.tabsize);
+
+    return false;
   }
 
   function doSync() {

--- a/public/scss/components/_settings.scss
+++ b/public/scss/components/_settings.scss
@@ -48,6 +48,16 @@
   .has-checkbox {
     float: left;
   }
+  
+  form {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  input {
+    width: 20%;
+  }
 
 // -------------------------------------
 //   Scaffolding

--- a/views/dropdowns/settings.ejs
+++ b/views/dropdowns/settings.ejs
@@ -31,6 +31,12 @@
     </a>
   </li>
   <% } %>
+  <li>
+    <a><form>
+      <span>Tab Size</span>
+      <input type="number" ng-model="tabsize" min="1" ng-change="user.storeTabSize()"></input>
+    </form></a>
+  </li>
   <!--
   <li>
     <a ng-click="user.toggleNightMode()">


### PR DESCRIPTION
PR for #584 

1. Stores default value of tabSize = 4 in userService
2. On startup, run `setTabSize()` which pulls the tabSize value from the userService into the $scope and sets the Tab Size in the Ace Editor. `$scope.tabsize` is used in the UI as the value displayed in the menu
3. This menu item is displayed in Settings dropdown menu and calls `storeTabSize()` when the value is changed (some CSS was added to make this menu item look OK)
4. `storeTabSize()` saves the value in `$scope.tabsize` to the userService profile and then runs `setTabSize()` to change the Ace setting accordingly

Some notes:
* I had to pull `$scope` into the controller to display the tab size value in the UI
* Since tabs are converted to spaces in the editor, changing the `tabSize` in code doesn't change the existing "tabs" in the editor. [The Markdown spec actually says tabs shouldn't be converted to spaces](https://spec.commonmark.org/0.28/#tabs), so this may require future work.
* [An indented code block is made from 4 spaces](https://spec.commonmark.org/0.28/#indented-code-blocks), so when a tab is less than 4, a single tab won't create a code block. (Really just an FYI. I'm using to using a tab to create a code block so this came as a surprise to me.)
* To reduce the amount of CSS I had to add, this menu item still has the `<a>` tag so the text changes color when hovered over. Is this OK or would you rather have the gray or green text?

Tabs set to 2 showing tab markers and how code blocks work
![image](https://user-images.githubusercontent.com/1299430/46810682-332cae00-cd3f-11e8-8036-44d6ed6cf969.png)

Tab Size menu item (not hovered)
![image](https://user-images.githubusercontent.com/1299430/46810696-417aca00-cd3f-11e8-8efb-42aee7827611.png)

Tab Size menu item (hovered, text changes green)
![image](https://user-images.githubusercontent.com/1299430/46810892-a0d8da00-cd3f-11e8-90a8-fc0836c0568e.png)


