### PR TITLE
Append `.md` to H1 after it is found

### DIFF
--- a/public/js/user/user.controller.js
+++ b/public/js/user/user.controller.js
@@ -144,7 +144,7 @@ module.exports =
   function setDocumentTitleToFirstHeader() {
     // set the document's name to the first header if there is one
     try {
-      documentsService.setCurrentDocumentTitle(angular.element(document).find('#preview').find('h1')[0].textContent);
+      documentsService.setCurrentDocumentTitle(angular.element(document).find('#preview').find('h1')[0].textContent + ".md");
     }
     // don't do anything if there's no header
     catch(err) {}


### PR DESCRIPTION
Follow up to https://github.com/joemccann/dillinger/pull/696#issuecomment-428971741
That PR added a feature to set the current document title to the first title in pasted text.
This PR just appends a `.md` onto the title.

(I couldn't figure out how to add this commit to the old PR. Maybe I couldn't do it because it's already merged?)