### PR TITLE
Change Breakdance URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Dillinger uses a number of open source projects to work properly:
 * [node.js] - evented I/O for the backend
 * [Express] - fast node.js network app framework [@tjholowaychuk]
 * [Gulp] - the streaming build system
-* [Breakdance](http://breakdance.io) - HTML to Markdown converter
+* [Breakdance](https://breakdance.github.io/breakdance/) - HTML to Markdown converter
 * [jQuery] - duh
 
 And of course Dillinger itself is open source with a [public repository][dill]


### PR DESCRIPTION
Breakdance is no longer hosted at breakdance.io.