### PR TITLE
PDF export working on Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,44 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ttf-wqy-microhei \
   ttf-wqy-zenhei \ 
   software-properties-common \
+  gconf-service \
+  libasound2 \
+  libatk1.0-0 \
+  libatk-bridge2.0-0 \
+  libc6 \
+  libcairo2 \
+  libcups2 \
+  libdbus-1-3 \
+  libexpat1 \
+  libfontconfig1 \
+  libgcc1 \
+  libgconf-2-4 \
+  libgdk-pixbuf2.0-0 \
+  libglib2.0-0 \
+  libgtk-3-0 \
+  libnspr4 \
+  libpango-1.0-0 \
+  libpangocairo-1.0-0 \
+  libstdc++6 \
+  libx11-6 \
+  libx11-xcb1 \
+  libxcb1 \
+  libxcomposite1 \
+  libxcursor1 \
+  libxdamage1 \
+  libxext6 \
+  libxfixes3 \
+  libxi6 \
+  libxrandr2 \
+  libxrender1 \
+  libxss1 \
+  libxtst6 \
+  fonts-liberation \
+  libappindicator1 \
+  libnss3 \
+  lsb-release \
+  xdg-utils \
+  wget \
   && rm -rf /var/lib/apt/lists/*
 
 # this is faster via npm run build-docker
@@ -23,6 +61,11 @@ RUN npm install --devDependencies \
 RUN rm -rf /configs
 RUN mkdir -p /configs
 COPY . .
+
+RUN echo 'kernel.unprivileged_userns_clone=1' > /etc/sysctl.d/userns.conf
+RUN adduser --disabled-password --gecos '' dillinger
+RUN chown -R dillinger:dillinger /public
+USER dillinger
 
 EXPOSE 8080
 ENV NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ By default, the Docker will expose port 8080, so change this within the Dockerfi
 
 ```sh
 cd dillinger
-docker build -t joemccann/dillinger:${package.json.version} .
+docker build -t <youruser>/dillinger:${package.json.version} .
 ```
 This will create the dillinger image and pull in the necessary dependencies. Be sure to swap out `${package.json.version}` with the actual version of Dillinger.
 
 Once done, run the Docker image and map the port to whatever you wish on your host. In this example, we simply map port 8000 of the host to port 8080 of the Docker (or whatever port was exposed in the Dockerfile):
 
 ```sh
-docker run -d -p 8000:8080 --restart="always" <youruser>/dillinger:${package.json.version}
+docker run -d -p 8000:8080 --restart=always --cap-add=SYS_ADMIN --name=dillinger <youruser>/dillinger:${package.json.version}
 ```
 
 Verify the deployment by navigating to your server address in your preferred browser.


### PR DESCRIPTION
Ref. issue #735

To solve this issue I had to install some puppeteer dependencies with apt-get, then create a non-root user and execute the application under that user.

Also, the container must be created with the flag `--cap-add=SYS_ADMIN`, I updated the README accordingly.