### PR TITLE
Update GitHub plugin to use HTTP headers

### DIFF
--- a/plugins/github/github.js
+++ b/plugins/github/github.js
@@ -48,16 +48,30 @@ exports.Github = (function() {
 
   // String builder for auth url...
   function _buildAuthUrl(scope) {
-    return  'https://github.com/login/oauth/authorize?client_id='
-            + githubConfig.client_id
-            + '&scope=' + scope + '&redirect_uri='
-            + githubConfig.callback_url
+    return  'https://github.com/login/oauth/authorize?scope=' + scope + 
+            '&redirect_uri=' + githubConfig.callback_url
   }
 
   function _buildHeaders(req) {
     return {
       "User-Agent"    : "X-Dillinger-App",
       "Authorization" : "token " + req.session.github.oauth
+    }
+  }
+  
+  function _buildAuth() {
+    return {
+      'user': githubConfig.client_id,
+      'pass': githubConfig.client_secret,
+      'sendImmediately': true
+    } 
+  }
+  
+  function _buildOptions(req,uri) {
+    return {
+        headers: _buildHeaders(req),
+        auth: _buildAuth(),
+        uri: uri
     }
   }
   
@@ -77,11 +91,7 @@ exports.Github = (function() {
     getUsername: function(req, res, cb) {
 
       var uri = githubApi + 'user';
-
-      var options = {
-        headers: _buildHeaders(req),
-        uri: uri
-      }
+      const options = _buildOptions(req,uri);
 
       console.log('getting username from github')
 
@@ -110,10 +120,7 @@ exports.Github = (function() {
         uri = githubApi + 'users/' + req.session.github.username + '/orgs'
       }
 
-      var options = {
-        headers: _buildHeaders(req),
-        uri: uri
-      }
+      const options = _buildOptions(req,uri);
 
       request(options, function(e, r, d) {
         if (e) {
@@ -169,11 +176,7 @@ exports.Github = (function() {
       }
 
       uri += "&type=owner"
-
-      var options = {
-        headers: _buildHeaders(req),
-        uri: uri
-      }
+      const options = _buildOptions(req,uri)
 
       request(options, function(e, r, d) {
         if (e) {
@@ -220,10 +223,7 @@ exports.Github = (function() {
         + req.body.repo
         + '/branches'
 
-      var options = {
-        headers: _buildHeaders(req),
-        uri: uri
-      }
+      const options = _buildOptions(req,uri)
 
       request(options, function(e, r, d) {
         if (e) {
@@ -244,7 +244,7 @@ exports.Github = (function() {
     fetchTreeFiles: function(req, res) {
       // /repos/:user/:repo/git/trees/:sha
 
-      var uri, options, fileExts, regExp
+      var uri, fileExts, regExp
 
       uri = githubApi
         + 'repos/'
@@ -255,10 +255,7 @@ exports.Github = (function() {
         + req.body.sha + '?recursive=1'
         ;
 
-      options = {
-        headers: _buildHeaders(req),
-        uri: uri
-      };
+      const options = _buildOptions(req,uri);
 
       fileExts = req.body.fileExts.split("|");
       regExp = arrayToRegExp(fileExts);
@@ -297,10 +294,7 @@ exports.Github = (function() {
       //   uri += '?access_token=' + req.session.github.oauth
       // }
 
-      var options = {
-        headers: _buildHeaders(req), // TODO remove token for public repo?
-        uri: uri
-      }
+      const options = _buildOptions(req,uri); // TODO remove token for public repo?
 
       request(options, function(e, r, d) {
         if (e) {
@@ -365,8 +359,7 @@ exports.Github = (function() {
       };
 
         options = {
-          headers: _buildHeaders(req),
-          uri: uri,
+          ..._buildOptions(req,uri),
           method: "PUT",
           body: JSON.stringify(commit)
         }

--- a/plugins/github/github.js
+++ b/plugins/github/github.js
@@ -48,7 +48,7 @@ exports.Github = (function() {
 
   // String builder for auth url...
   function _buildAuthUrl(scope) {
-    return  'https://github.com/login/oauth/authorize?scope=' + scope + 
+    return  'https://github.com/login/oauth/authorize?scope=' + scope +
             '&redirect_uri=' + githubConfig.callback_url
   }
 
@@ -58,23 +58,26 @@ exports.Github = (function() {
       "Authorization" : "token " + req.session.github.oauth
     }
   }
-  
+
   function _buildAuth() {
     return {
       'user': githubConfig.client_id,
       'pass': githubConfig.client_secret,
       'sendImmediately': true
-    } 
-  }
-  
-  function _buildOptions(req,uri) {
-    return {
-        headers: _buildHeaders(req),
-        auth: _buildAuth(),
-        uri: uri
     }
   }
-  
+
+  function _buildOptions(req,uri) {
+    const options = {
+        headers: _buildHeaders(req),
+        uri: uri
+    }
+    if ( githubConfig.client_id && githubConfig.client_secret ) {
+      options.auth = _buildAuth();
+    }
+    return options
+  }
+
   return {
     isConfigured: isConfigEnabled,
     githubConfig: githubConfig,
@@ -313,7 +316,7 @@ exports.Github = (function() {
 
           if (isPrivateRepo) {
             d = JSON.parse(d)
-            jsonResp.data.content = (new Buffer(d.content, 'base64').toString('utf-8'))
+            jsonResp.data.content = (Buffer.from(d.content, 'base64').toString('utf-8'))
           }
 
           res.json(jsonResp)
@@ -354,7 +357,7 @@ exports.Github = (function() {
           message: message // Better commit messages?
         , path: path
         , branch: branch
-        , content: new Buffer(data.data).toString('base64')
+        , content: Buffer.from(data.data).toString('base64')
         , sha: sha
       };
 
@@ -368,7 +371,7 @@ exports.Github = (function() {
           // 200 = Updated
           // 201 = Created
           // 409 = Conflict
-          var data 
+          var data
           try{
             data = JSON.parse(d)
           }catch(e){


### PR DESCRIPTION
GitHub is deprecating the use of URI parameters per September 2021, this patch fixes the API requests.
Limited testing (only personal access token) but seems to work for me