### PR TITLE
Updated Dockerfile to prevent apt becoming stuck on tzdata installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM nodesource/nsolid:latest
 LABEL maintainer "Joe McCann <joe@subprint.com>"
 
 # Install our dependencies (libfontconfig for phantomjs)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
   bzip2 \
   ca-certificates \
   curl \


### PR DESCRIPTION
The build from the included Dockerfile becomes stuck during the apt-get install. This is due to it attempting to install the dependency of tzdata which requires user input. It can be fixed with a simple environment variable.

Solution was sourced from https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image