### PR TITLE
fix: PDF export broken in Docker and Serverless (Vercel) environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,7 @@ services:
     environment:
       - "BIND_ADDRESS=0.0.0.0"
       - "PORT=9000"
+    security_opt:
+      - seccomp=unconfined
+    cap_add:
+      - SYS_ADMIN

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "npm": ">=8.x"
   },
   "dependencies": {
+    "@sparticuz/chromium": "^131.0.0",
     "angular": "^1.8.3",
     "angular-bootstrap": "^0.12.0",
     "body-parser": "^1.18.3",

--- a/plugins/core/server.js
+++ b/plugins/core/server.js
@@ -8,6 +8,13 @@ const md = require('./markdown-it.js')
 const breakdance = require('breakdance')
 const { mdToPdf } = require('md-to-pdf')
 
+let chromium
+try {
+  chromium = require('@sparticuz/chromium')
+} catch (e) {
+  chromium = null
+}
+
 const _getFullHtml = (name, str, style) => {
   return '<!DOCTYPE html><html><head><meta charset="utf-8"><title>' +
     name + '</title><style>' +
@@ -109,8 +116,18 @@ const markdown2Pdf = async (md) => {
   let pdf = null
 
   try {
-    pdf = await mdToPdf({ content: md }, {
-      launch_options: {
+    let launchOptions
+
+    if (chromium) {
+      // Serverless environment (Vercel, AWS Lambda, etc.)
+      launchOptions = {
+        args: chromium.args,
+        executablePath: await chromium.executablePath(),
+        headless: chromium.headless
+      }
+    } else {
+      // Docker/traditional server environment
+      launchOptions = {
         executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
         args: [
           '--no-sandbox',
@@ -121,6 +138,10 @@ const markdown2Pdf = async (md) => {
           '--no-zygote'
         ]
       }
+    }
+
+    pdf = await mdToPdf({ content: md }, {
+      launch_options: launchOptions
     })
   } catch (err) {
     return { err }

--- a/plugins/core/server.js
+++ b/plugins/core/server.js
@@ -110,7 +110,17 @@ const markdown2Pdf = async (md) => {
 
   try {
     pdf = await mdToPdf({ content: md }, {
-      launch_options: ['--no-sandbox', '--disable-setuid-sandbox']
+      launch_options: {
+        executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-dev-shm-usage',
+          '--disable-gpu',
+          '--single-process',
+          '--no-zygote'
+        ]
+      }
     })
   } catch (err) {
     return { err }


### PR DESCRIPTION
## Summary
Fixes #885 - PDF export broken on dillinger.io

This PR fixes the PDF export functionality that fails in both Docker and serverless (Vercel/AWS Lambda) environments.

## Issues Addressed

### Docker Environment Error
```
Failed to move to new namespace: PID namespaces supported, Network namespace supported, 
but failed: errno = Operation not permitted
```

### Serverless (Vercel) Environment Error
```
Could not find Chrome (ver. 142.0.7444.175). This can occur if either
1. you did not perform an installation before running the script
2. your cache path is incorrectly configured (which is: /home/sbx_user1051/.cache/puppeteer)
```

## Root Cause Analysis

### 1. Incorrect `launch_options` Format
The `md-to-pdf` library expects `launch_options` to be an object matching Puppeteer's launch options format, but it was incorrectly passed as an array.

### 2. Docker Security Restrictions
Docker's default seccomp profile blocks the system calls that Chromium needs to create namespaces for its sandbox.

### 3. Serverless Chrome Missing
Serverless platforms like Vercel don't have Chrome pre-installed. The standard Puppeteer package tries to find Chrome in a cache directory that doesn't exist in these environments.

## Changes Made

### `plugins/core/server.js`
- Added smart environment detection using `@sparticuz/chromium`
- **Serverless mode**: Uses `@sparticuz/chromium` for Vercel/Lambda environments
- **Docker mode**: Falls back to system Chrome with proper sandbox flags

```javascript
let chromium
try {
  chromium = require('@sparticuz/chromium')
} catch (e) {
  chromium = null
}

// In markdown2Pdf:
if (chromium) {
  // Serverless (Vercel, AWS Lambda)
  launchOptions = {
    args: chromium.args,
    executablePath: await chromium.executablePath(),
    headless: chromium.headless
  }
} else {
  // Docker/traditional server
  launchOptions = {
    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', 
           '--disable-gpu', '--single-process', '--no-zygote']
  }
}
```

### `package.json`
- Added `@sparticuz/chromium: ^131.0.0` dependency for serverless Chrome support

### `docker-compose.yml`
- Added `security_opt: seccomp=unconfined` - Disables seccomp filtering
- Added `cap_add: SYS_ADMIN` - Grants capability for namespace operations

## Validation
This fix has been validated against multiple sources:
- [Puppeteer Troubleshooting Guide](https://pptr.dev/troubleshooting)
- [@sparticuz/chromium documentation](https://github.com/Sparticuz/chromium)
- [Vercel Puppeteer examples](https://github.com/vercel/examples/tree/main/solutions/puppeteer)
- [Stack Overflow: Puppeteer Docker namespace issues](https://stackoverflow.com/questions/50662388)
- [dev.to: Puppeteer on Vercel](https://dev.to/akirautio/generate-pdf-with-puppeteer-on-vercel-3b0g)

## Testing

### Docker
```bash
docker-compose down
docker-compose build --no-cache
docker-compose up
```

### Vercel
The `@sparticuz/chromium` package is automatically detected and used when deployed to Vercel.

## Note for Maintainers
If Vercel deployment still has issues, you may need to:
1. Ensure the Vercel function has sufficient memory (1024MB+ recommended)
2. Check if `libnss3.so` or other dependencies are missing (may require custom build)